### PR TITLE
feat: initialize uv workspaces monorepo

### DIFF
--- a/infra/pyproject.toml
+++ b/infra/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "grading-infra"
+version = "0.1.0"
+description = "AWS CDK infrastructure package for grading-cloud."
+requires-python = ">=3.12"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "grading-cloud"
+version = "0.1.0"
+description = "Cloud-native grading pipeline monorepo."
+requires-python = ">=3.12"
+dependencies = []
+
+[tool.uv.workspace]
+members = ["shared", "services/*"]

--- a/services/batch-poller/pyproject.toml
+++ b/services/batch-poller/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "batch-poller"
+version = "0.1.0"
+description = "Lambda service polling Anthropic batch processing status."
+requires-python = ">=3.12"
+dependencies = ["grading_shared"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv.sources]
+grading_shared = { workspace = true }

--- a/services/exam-api/pyproject.toml
+++ b/services/exam-api/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "exam-api"
+version = "0.1.0"
+description = "FastAPI orchestration service for grading-cloud."
+requires-python = ">=3.12"
+dependencies = ["grading_shared"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv.sources]
+grading_shared = { workspace = true }

--- a/services/pdf-generator/pyproject.toml
+++ b/services/pdf-generator/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "pdf-generator"
+version = "0.1.0"
+description = "Lambda service generating PDF reports from grading data."
+requires-python = ">=3.12"
+dependencies = ["grading_shared"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv.sources]
+grading_shared = { workspace = true }

--- a/services/spreadsheet-converter/pyproject.toml
+++ b/services/spreadsheet-converter/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "spreadsheet-converter"
+version = "0.1.0"
+description = "Lambda service converting spreadsheets to structured JSON."
+requires-python = ">=3.12"
+dependencies = ["grading_shared"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv.sources]
+grading_shared = { workspace = true }

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "grading_shared"
+version = "0.1.0"
+description = "Shared domain models and ports for grading-cloud services."
+requires-python = ">=3.12"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
- create a root `uv` workspace in `pyproject.toml` with members `shared` and `services/*`
- bootstrap `grading_shared` package metadata in `shared/pyproject.toml`
- scaffold service package manifests for `exam-api`, `spreadsheet-converter`, `batch-poller`, and `pdf-generator` wired to the workspace `grading_shared` dependency
- add `infra/pyproject.toml` to initialize the infrastructure Python package

## Test plan
- [x] verify workspace and package manifests are present at expected paths
- [x] ensure only issue #1 scaffold files are committed

Closes #1

Made with [Cursor](https://cursor.com)