### PR TITLE
feat: implement grading_shared package foundation

### DIFF
--- a/shared/grading_shared/__init__.py
+++ b/shared/grading_shared/__init__.py
@@ -1,0 +1,2 @@
+"""Shared package for grading-cloud domain and ports."""
+

--- a/shared/grading_shared/domain/__init__.py
+++ b/shared/grading_shared/domain/__init__.py
@@ -1,0 +1,28 @@
+"""Domain layer for shared grading-cloud models."""
+
+from .events import EventType, PipelineEvent
+from .exam import Exam, ExamStatus
+from .models import (
+    MetaModel,
+    Niveau1Model,
+    Niveau2Model,
+    Niveau3Model,
+    NotationPayload,
+    StudentModel,
+    TotauxModel,
+)
+
+__all__ = [
+    "Exam",
+    "ExamStatus",
+    "EventType",
+    "MetaModel",
+    "Niveau1Model",
+    "Niveau2Model",
+    "Niveau3Model",
+    "NotationPayload",
+    "PipelineEvent",
+    "StudentModel",
+    "TotauxModel",
+]
+

--- a/shared/grading_shared/domain/events.py
+++ b/shared/grading_shared/domain/events.py
@@ -1,0 +1,32 @@
+"""Domain events for the grading pipeline."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import Field
+
+from .models import StrictModel
+
+
+class EventType(StrEnum):
+    SPREADSHEET_CONVERTED = "spreadsheet_converted"
+    CORRECTION_BATCH_STARTED = "correction_batch_started"
+    CORRECTION_BATCH_COMPLETED = "correction_batch_completed"
+    HARMONIZATION_BATCH_STARTED = "harmonization_batch_started"
+    HARMONIZATION_BATCH_COMPLETED = "harmonization_batch_completed"
+    PDF_GENERATED = "pdf_generated"
+    PIPELINE_COMPLETED = "pipeline_completed"
+    PIPELINE_FAILED = "pipeline_failed"
+
+
+class PipelineEvent(StrictModel):
+    event_id: str
+    event_type: EventType
+    exam_id: str
+    occurred_at: str
+    student_id: str | None = None
+    batch_id: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+

--- a/shared/grading_shared/domain/exam.py
+++ b/shared/grading_shared/domain/exam.py
@@ -1,0 +1,48 @@
+"""Exam aggregate and status state machine."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from .models import StrictModel
+
+
+class ExamStatus(StrEnum):
+    DRAFT = "draft"
+    READY = "ready"
+    INGESTION_RUNNING = "ingestion_running"
+    CORRECTION_RUNNING = "correction_running"
+    HARMONIZATION_RUNNING = "harmonization_running"
+    PDF_GENERATION_RUNNING = "pdf_generation_running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+_ALLOWED_TRANSITIONS: dict[ExamStatus, set[ExamStatus]] = {
+    ExamStatus.DRAFT: {ExamStatus.READY, ExamStatus.FAILED},
+    ExamStatus.READY: {ExamStatus.INGESTION_RUNNING, ExamStatus.FAILED},
+    ExamStatus.INGESTION_RUNNING: {ExamStatus.CORRECTION_RUNNING, ExamStatus.FAILED},
+    ExamStatus.CORRECTION_RUNNING: {ExamStatus.HARMONIZATION_RUNNING, ExamStatus.FAILED},
+    ExamStatus.HARMONIZATION_RUNNING: {ExamStatus.PDF_GENERATION_RUNNING, ExamStatus.FAILED},
+    ExamStatus.PDF_GENERATION_RUNNING: {ExamStatus.COMPLETED, ExamStatus.FAILED},
+    ExamStatus.COMPLETED: set(),
+    ExamStatus.FAILED: set(),
+}
+
+
+class Exam(StrictModel):
+    exam_id: str
+    teacher_id: str
+    title: str
+    status: ExamStatus = ExamStatus.DRAFT
+
+    def can_transition_to(self, target_status: ExamStatus) -> bool:
+        return target_status in _ALLOWED_TRANSITIONS[self.status]
+
+    def transition_to(self, target_status: ExamStatus) -> None:
+        if not self.can_transition_to(target_status):
+            raise ValueError(
+                f"Invalid exam status transition from {self.status} to {target_status}."
+            )
+        self.status = target_status
+

--- a/shared/grading_shared/domain/models.py
+++ b/shared/grading_shared/domain/models.py
@@ -1,0 +1,64 @@
+"""Pydantic models shared across grading-cloud services."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class StrictModel(BaseModel):
+    """Base model enforcing strict payload validation."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+
+class StudentModel(StrictModel):
+    student_id: str
+    first_name: str
+    last_name: str
+
+
+class Niveau3Model(StrictModel):
+    criterion_id: str
+    label: str
+    max_points: float = Field(ge=0)
+    points_awarded: float = Field(ge=0)
+    feedback: str
+
+
+class Niveau2Model(StrictModel):
+    criterion_id: str
+    label: str
+    max_points: float = Field(ge=0)
+    points_awarded: float = Field(ge=0)
+    criteres_niveau3: list[Niveau3Model] = Field(default_factory=list)
+
+
+class Niveau1Model(StrictModel):
+    criterion_id: str
+    label: str
+    max_points: float = Field(ge=0)
+    points_awarded: float = Field(ge=0)
+    criteres_niveau2: list[Niveau2Model] = Field(default_factory=list)
+
+
+class TotauxModel(StrictModel):
+    total_max_points: float = Field(ge=0)
+    total_points_awarded: float = Field(ge=0)
+    percentage: float = Field(ge=0, le=100)
+    grade: float = Field(ge=0)
+
+
+class MetaModel(StrictModel):
+    corrected_at: str
+    correction_model: str
+    rubric_version: str
+    language: str = "fr"
+
+
+class NotationPayload(StrictModel):
+    exam_id: str
+    student: StudentModel
+    criteres_niveau1: list[Niveau1Model] = Field(default_factory=list)
+    totaux: TotauxModel
+    meta: MetaModel
+

--- a/shared/grading_shared/ports/__init__.py
+++ b/shared/grading_shared/ports/__init__.py
@@ -2,70 +2,62 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 from grading_shared.domain.events import PipelineEvent
 from grading_shared.domain.exam import Exam
 from grading_shared.domain.models import NotationPayload
 
 
-class FileStoragePort(ABC):
-    @abstractmethod
+@runtime_checkable
+class FileStoragePort(Protocol):
     def put_json(self, *, key: str, payload: dict[str, Any]) -> None:
         """Store JSON-serializable data."""
 
-    @abstractmethod
     def get_json(self, *, key: str) -> dict[str, Any]:
         """Fetch JSON-serializable data."""
 
-    @abstractmethod
     def put_binary(self, *, key: str, content: bytes, content_type: str) -> None:
         """Store binary content."""
 
 
-class ExamRepositoryPort(ABC):
-    @abstractmethod
+@runtime_checkable
+class ExamRepositoryPort(Protocol):
     def save_exam(self, exam: Exam) -> None:
         """Persist an exam aggregate."""
 
-    @abstractmethod
     def get_exam(self, *, exam_id: str) -> Exam | None:
         """Load an exam aggregate by its identifier."""
 
-    @abstractmethod
     def save_notation_payload(
         self, *, exam_id: str, student_id: str, payload: NotationPayload
     ) -> None:
         """Persist a student's notation payload."""
 
 
-class AIBatchPort(ABC):
-    @abstractmethod
+@runtime_checkable
+class AIBatchPort(Protocol):
     def create_batch(self, *, batch_name: str, requests: list[dict[str, Any]]) -> str:
         """Create an AI batch and return its provider identifier."""
 
-    @abstractmethod
     def get_batch_status(self, *, batch_id: str) -> str:
         """Return provider batch status."""
 
-    @abstractmethod
     def get_batch_results(self, *, batch_id: str) -> list[dict[str, Any]]:
         """Return provider batch results."""
 
 
-class MessagePublisherPort(ABC):
-    @abstractmethod
+@runtime_checkable
+class MessagePublisherPort(Protocol):
     def publish_pipeline_event(self, event: PipelineEvent) -> None:
         """Publish a pipeline event."""
 
 
-class SchedulerPort(ABC):
-    @abstractmethod
+@runtime_checkable
+class SchedulerPort(Protocol):
     def schedule_batch_polling(self, *, batch_id: str, interval_minutes: int) -> str:
         """Create a polling schedule and return schedule identifier."""
 
-    @abstractmethod
     def remove_schedule(self, *, schedule_id: str) -> None:
         """Delete a previously created schedule."""
 

--- a/shared/grading_shared/ports/__init__.py
+++ b/shared/grading_shared/ports/__init__.py
@@ -1,0 +1,71 @@
+"""Application ports for grading-cloud adapters."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from grading_shared.domain.events import PipelineEvent
+from grading_shared.domain.exam import Exam
+from grading_shared.domain.models import NotationPayload
+
+
+class FileStoragePort(ABC):
+    @abstractmethod
+    def put_json(self, *, key: str, payload: dict[str, Any]) -> None:
+        """Store JSON-serializable data."""
+
+    @abstractmethod
+    def get_json(self, *, key: str) -> dict[str, Any]:
+        """Fetch JSON-serializable data."""
+
+    @abstractmethod
+    def put_binary(self, *, key: str, content: bytes, content_type: str) -> None:
+        """Store binary content."""
+
+
+class ExamRepositoryPort(ABC):
+    @abstractmethod
+    def save_exam(self, exam: Exam) -> None:
+        """Persist an exam aggregate."""
+
+    @abstractmethod
+    def get_exam(self, *, exam_id: str) -> Exam | None:
+        """Load an exam aggregate by its identifier."""
+
+    @abstractmethod
+    def save_notation_payload(
+        self, *, exam_id: str, student_id: str, payload: NotationPayload
+    ) -> None:
+        """Persist a student's notation payload."""
+
+
+class AIBatchPort(ABC):
+    @abstractmethod
+    def create_batch(self, *, batch_name: str, requests: list[dict[str, Any]]) -> str:
+        """Create an AI batch and return its provider identifier."""
+
+    @abstractmethod
+    def get_batch_status(self, *, batch_id: str) -> str:
+        """Return provider batch status."""
+
+    @abstractmethod
+    def get_batch_results(self, *, batch_id: str) -> list[dict[str, Any]]:
+        """Return provider batch results."""
+
+
+class MessagePublisherPort(ABC):
+    @abstractmethod
+    def publish_pipeline_event(self, event: PipelineEvent) -> None:
+        """Publish a pipeline event."""
+
+
+class SchedulerPort(ABC):
+    @abstractmethod
+    def schedule_batch_polling(self, *, batch_id: str, interval_minutes: int) -> str:
+        """Create a polling schedule and return schedule identifier."""
+
+    @abstractmethod
+    def remove_schedule(self, *, schedule_id: str) -> None:
+        """Delete a previously created schedule."""
+


### PR DESCRIPTION
## Summary
- add `shared/grading_shared/domain/models.py` with strict Pydantic v2 models: `NotationPayload`, `StudentModel`, `Niveau1Model`, `Niveau2Model`, `Niveau3Model`, `TotauxModel`, `MetaModel`
- add `shared/grading_shared/domain/exam.py` with `ExamStatus` and `Exam` state machine transitions
- add `shared/grading_shared/domain/events.py` with `EventType` and `PipelineEvent`
- add `shared/grading_shared/ports/__init__.py` with ABC ports: `FileStoragePort`, `ExamRepositoryPort`, `AIBatchPort`, `MessagePublisherPort`, `SchedulerPort`
- keep `domain/` and `ports/` free of AWS imports

## Test plan
- [x] `uv run pytest` (executed; no tests collected in repository)

Closes #7

Made with [Cursor](https://cursor.com)