### PR TITLE
feat: add CDK frontend stack with S3 and CloudFront OAC

### DIFF
--- a/infra/stacks/frontend_stack.py
+++ b/infra/stacks/frontend_stack.py
@@ -1,0 +1,33 @@
+from aws_cdk import RemovalPolicy, Stack
+from aws_cdk import aws_cloudfront as cloudfront
+from aws_cdk import aws_cloudfront_origins as origins
+from aws_cdk import aws_s3 as s3
+from constructs import Construct
+
+
+class FrontendStack(Stack):
+    def __init__(self, scope: Construct, construct_id: str, **kwargs: object) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        self.frontend_bucket = s3.Bucket(
+            self,
+            "FrontendBucket",
+            bucket_name="grading-frontend-bucket",
+            versioned=True,
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            enforce_ssl=True,
+            auto_delete_objects=False,
+            removal_policy=RemovalPolicy.RETAIN,
+        )
+
+        self.distribution = cloudfront.Distribution(
+            self,
+            "FrontendDistribution",
+            default_behavior=cloudfront.BehaviorOptions(
+                origin=origins.S3BucketOrigin.with_origin_access_control(
+                    self.frontend_bucket
+                ),
+                viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+            ),
+            default_root_object="index.html",
+        )


### PR DESCRIPTION
## Summary
- Add `FrontendStack` in CDK Python under `infra/stacks/frontend_stack.py`.
- Provision a private S3 bucket for static frontend assets.
- Serve the bucket through a CloudFront distribution with Origin Access Control (OAC) and HTTPS redirection.

## Test plan
- [x] `python3 -m compileall infra`
- [ ] `cd infra && uv run cdk synth`
- [ ] Deploy to a sandbox AWS account and validate CloudFront serves from S3 over HTTPS.

Made with [Cursor](https://cursor.com)