### PR TITLE
ci: add Claude automation workflows

### DIFF
--- a/.github/workflows/claude-ci-failure.yml
+++ b/.github/workflows/claude-ci-failure.yml
@@ -1,0 +1,53 @@
+name: Claude CI Failure Analysis
+
+on:
+  workflow_run:
+    workflows: ["Tests", "Lint"]
+    types: [completed]
+    branches-ignore: [main]
+
+jobs:
+  analyze:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Download failed CI logs and find PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run view ${{ github.event.workflow_run.id }} --log-failed 2>&1 \
+            | head -c 8000 > /tmp/ci_failure.log \
+            || echo "Logs indisponibles" > /tmp/ci_failure.log
+
+          PR=$(gh pr list \
+            --head "${{ github.event.workflow_run.head_branch }}" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty' 2>/dev/null || echo "")
+          echo "${PR:-}" > /tmp/pr_number.txt
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Le workflow CI "${{ github.event.workflow_run.name }}" a échoué
+            sur la branche ${{ github.event.workflow_run.head_branch }}.
+
+            1. Lis /tmp/ci_failure.log — logs d'erreur du run échoué
+            2. Identifie la cause racine (fichier + ligne si possible)
+            3. Propose un fix minimal (moins de 10 lignes)
+            4. Indique : problème de code, de config, ou de test ?
+            5. Lis /tmp/pr_number.txt. Si non vide, poste l'analyse avec :
+               gh pr comment {numéro} --body "## CI Failure Analysis\n\n{ton analyse}"
+
+            Ne modifie aucun fichier source.

--- a/.github/workflows/claude-issue-scaffold.yml
+++ b/.github/workflows/claude-issue-scaffold.yml
@@ -1,0 +1,43 @@
+name: Claude Issue Scaffold
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  scaffold:
+    if: github.event.label.name == 'ai-scaffold'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write issue context
+        env:
+          BODY: ${{ github.event.issue.body }}
+        run: printf '%s' "$BODY" > /tmp/issue_body.txt
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Issue #${{ github.event.issue.number }} : ${{ github.event.issue.title }}
+            Lis /tmp/issue_body.txt pour la description complète.
+
+            Ta mission :
+            1. Lis CLAUDE.md pour les conventions du projet
+            2. Analyse le code existant pour trouver les patterns à suivre
+            3. Crée la branche feature/issue-${{ github.event.issue.number }}-{slug}
+            4. Génère des stubs avec TODOs uniquement — pas d'implémentation complète
+               Ordre : domain → ports → application → infrastructure → api
+            5. Ajoute un fichier tests/ vide listant les cas à implémenter
+            6. Ouvre une draft PR "Closes #${{ github.event.issue.number }}"
+            7. Retire le label de l'issue :
+               gh issue edit ${{ github.event.issue.number }} --remove-label "ai-scaffold"
+
+            Suis exactement les patterns des fichiers existants dans le même service.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,41 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - '.github/**'
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Tu es un tech lead senior qui review une PR sur un projet
+            Python/FastAPI avec architecture hexagonale sur AWS.
+
+            Analyse dans l'ordre de priorité :
+            1. Violations architecture hexagonale (import boto3 dans domain/ ?)
+            2. Sécurité : credentials exposés, IAM trop large, injection
+            3. Correctness : logique métier, edge cases non gérés
+            4. Performance DynamoDB : scan full-table, N+1
+            5. Tests manquants ou insuffisants
+            6. Conformité Pydantic v2 (extra="forbid", strict=True)
+
+            Format : [CRITIQUE|MAJEUR|MINEUR] + fichier:ligne + fix en 2 lignes.
+            Sois bref. Pas de félicitations.


### PR DESCRIPTION
## Summary
- add `claude-review.yml` to run automated Claude PR review on non-draft pull requests
- add `claude-ci-failure.yml` to analyze failed CI workflow runs and comment root-cause guidance on related PRs
- add `claude-issue-scaffold.yml` to scaffold draft implementation branches when an issue is labeled `ai-scaffold`

## Secrets required
- `ANTHROPIC_API_KEY` (repository secret)
- `GITHUB_TOKEN` is provided automatically by GitHub Actions

## Test plan
- [x] Validate workflow YAML syntax via repository diff review
- [ ] Trigger each workflow in GitHub after merge (PR open, CI failure, issue label)

Made with [Cursor](https://cursor.com)