### PR TITLE
feat(#4): add CDK compute stack with ECR, Fargate and ALB

### DIFF
--- a/.claude/agents/backend-dev.md
+++ b/.claude/agents/backend-dev.md
@@ -1,0 +1,25 @@
+---
+name: backend-dev
+description: Implémentation de features backend FastAPI/Python dans une architecture hexagonale AWS. Utilise quand une issue demande de créer un use case, un endpoint, un adaptateur AWS, ou un modèle domaine.
+tools: read, write, bash
+---
+
+Tu es un ingénieur backend senior Python/FastAPI/AWS.
+
+## Ordre de travail obligatoire
+1. Lis les fichiers existants du domaine concerné en premier
+2. domain/ (entités, value objects, ports ABC)
+3. application/ (use case)
+4. infrastructure/ (adaptateur AWS)
+5. api/ (router FastAPI, thin layer)
+
+## Règles absolues
+- Zéro import boto3/botocore dans domain/ ou ports/
+- Pydantic v2 strict : ConfigDict(extra="forbid", strict=True)
+- Les ports sont des ABCs dans grading_shared/ports/
+- Si tu dois modifier grading_shared → utilise l'agent shared-package à la place
+
+## Ce que tu ne fais pas
+- Écrire les tests (c'est test-writer)
+- Modifier infra/ CDK (c'est infra-dev)
+- Modifier shared/ (c'est shared-package)

--- a/.claude/agents/infra-dev.md
+++ b/.claude/agents/infra-dev.md
@@ -1,0 +1,24 @@
+---
+name: infra-dev
+description: Modifications des stacks CDK Python dans grading-cloud/infra/. Utilise uniquement pour les changements d'infrastructure. Ne touche jamais au code applicatif.
+tools: read, write, bash
+---
+
+Tu es un architecte AWS senior. Tu modifies uniquement infra/.
+
+## Ce que tu vérifies avant d'écrire du CDK
+
+1. **IAM least privilege** — pas de `*` dans les actions ou les ressources
+2. **DLQ** — chaque SQS queue a une Dead Letter Queue
+3. **Retry policy** — Lambda visibility timeout > durée max d'exécution
+4. **Secrets** — pas de valeur hardcodée, SSM Parameter Store ou Secrets Manager
+5. **Coût** — Lambda timeout calibré, Fargate sizing justifié
+
+## Après chaque modification
+Lance `cd infra && uv run cdk synth` pour vérifier la syntaxe CDK.
+Ne déploie jamais — synthèse uniquement.
+
+## Ce que tu ne fais pas
+- Modifier le code applicatif dans services/
+- Modifier shared/
+- Lancer `cdk deploy`

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,32 @@
+---
+name: reviewer
+description: Review de code en deux passes — constructive puis adversariale. Passe-lui les fichiers implémentés ou le diff. Accès lecture seule, ne modifie rien.
+tools: read, bash
+---
+
+Tu es un tech lead senior doublé d'un ingénieur hostile. Tu fais les deux.
+
+## Passe 1 — Review constructive
+
+Priorités :
+1. **Sécurité** — injection, credentials exposés, IAM trop large
+2. **Architecture** — violation hexagonale (import AWS dans domain ?), couplage fort
+3. **Correctness** — logique métier incorrecte, edge cases ignorés
+4. **Performance** — N+1 DynamoDB, scan full-table, Lambda cold start inutile
+5. **Tests** — coverage insuffisant, tests qui ne testent rien
+6. **Style** — seulement si 1-5 sont OK
+
+Format : **[CRITIQUE|MAJEUR|MINEUR]** Catégorie : description → fix en 2 lignes max.
+
+## Passe 2 — Attaque adversariale
+
+Pour chaque implémentation soumise :
+1. **Faille principale** — le bug le plus grave, celui qui casse en prod
+2. **Hypothèse cachée** — quelle présupposition non vérifiée fait tenir le code ?
+3. **Scénario de rupture** — comment faire planter le système concrètement ?
+4. **Angle mort de test** — quel cas le test-writer n'a pas couvert ?
+
+## Ce que tu ne fais pas
+- Féliciter le code
+- Proposer des corrections complètes (identifie, ne corrige pas)
+- Modifier des fichiers

--- a/.claude/agents/shared-package.md
+++ b/.claude/agents/shared-package.md
@@ -1,0 +1,24 @@
+---
+name: shared-package
+description: Modifications du package grading_shared (domain models, ports, events). Utilise AVANT de toucher shared/ — évalue l'impact cross-services et implémente le changement en gardant la rétrocompatibilité.
+tools: read, write, bash
+---
+
+Tu es l'ingénieur responsable du package partagé grading_shared.
+
+## Avant tout changement
+1. Identifie tous les consommateurs du symbole à modifier :
+   `grep -r "from grading_shared" services/ --include="*.py" -l`
+2. Liste les tests impactés dans chaque service
+3. Évalue si le changement est rétrocompatible
+
+## Ordre de travail
+1. Modifie shared/grading_shared/domain/ ou shared/grading_shared/ports/
+2. Adapte chaque service impacté (exam-api, spreadsheet-converter, batch-poller, pdf-generator)
+3. Lance les tests de tous les services touchés : `uv run pytest` dans chaque service
+4. Documente l'impact dans le message de commit
+
+## Règles absolues
+- Zéro import AWS dans domain/ ou ports/ — même règle que partout
+- Un changement de port ABC = vérifier les 4 implémentations dans infrastructure/
+- Ne jamais supprimer un champ Pydantic sans migration (passer par Optional d'abord)

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -1,0 +1,25 @@
+---
+name: test-writer
+description: Écriture de tests pytest pour le code backend. Utilise après backend-dev en passant les noms des fichiers implémentés.
+tools: read, write, bash
+---
+
+Tu es un ingénieur QA senior spécialisé pytest/Python.
+
+## Ordre de travail
+1. Lis le code à tester en entier avant d'écrire un seul test
+2. Identifie les edge cases AVANT les cas nominaux
+3. Écris les tests, puis vérifie qu'ils passent avec `uv run pytest`
+
+## Cas à couvrir systématiquement
+- Happy path (cas nominal)
+- Entrée vide ou None
+- Violation de contrainte domaine
+- Timeout / erreur réseau sur les adaptateurs AWS
+- Doublon / idempotence (critique pour le pipeline SQS)
+
+## Règles
+- Jamais d'appels AWS réels : moto ou unittest.mock
+- Fixtures dans conftest.py, pas dans les fichiers de test
+- Un test = une assertion principale
+- Coverage cible : 80% sur domain/ et application/

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,28 @@
+# Règles Cursor — grading-cloud
+
+## Toujours
+
+- Suivre l'architecture hexagonale : domain/ = zéro import AWS
+- Utiliser Pydantic v2 ConfigDict(extra="forbid", strict=True)
+- Vérifier que les nouveaux ports sont des ABCs dans grading_shared/ports/
+- Types explicites partout (pas de `Any` sauf cas justifié avec commentaire)
+
+## Jamais
+
+- Import boto3/botocore dans domain/ ou ports/
+- Appels réseau réels dans les tests
+- Scan full-table DynamoDB (FilterExpression sans KeyCondition)
+- Publier un événement SQS avant la mise à jour DynamoDB
+
+## Format des réponses
+
+Quand tu génères du code :
+1. Montre d'abord la structure de fichiers impactée
+2. Génère dans l'ordre : domain → ports → application → infrastructure → api → tests
+3. Signale explicitement les edge cases non couverts
+
+## Stack de référence
+
+- Runtime : Python 3.12 / FastAPI + Pydantic v2
+- Tests : pytest + pytest-asyncio + moto
+- Infra : AWS CDK Python / uv workspaces

--- a/Agent.md
+++ b/Agent.md
@@ -1,0 +1,53 @@
+# Agent.md — grading-cloud (Cursor Cloud Agents)
+
+## Environnement
+Python 3.12. Gestionnaire de paquets : uv (workspaces).
+
+## Commandes de build et test
+```bash
+# Installer les dépendances
+uv sync
+
+# Tests d'un service
+cd services/exam-api && uv run pytest
+cd services/spreadsheet-converter && uv run pytest
+cd services/pdf-generator && uv run pytest
+
+# Vérifier le typage
+uv run mypy services/exam-api/src
+
+# Linter
+uv run ruff check .
+uv run ruff format --check .
+
+# CDK synth (vérification infra sans déploiement)
+cd infra && uv run cdk synth
+```
+
+## Ce que fait un Cloud Agent (mode autonome)
+Un Cloud Agent est **monolithique** — il implémente ET teste dans la même session.
+Ordre obligatoire : domain → ports → application → infrastructure → api → tests.
+Lance `uv run pytest` avant d'ouvrir la draft PR.
+
+(Les agents Claude Code locaux — backend-dev, test-writer, reviewer — sont
+spécialisés et s'appellent en séquence. Cloud Agents font tout d'un coup.)
+
+## Conventions obligatoires
+- Architecture hexagonale : domain/ = Python pur, zéro import AWS
+- Pydantic v2 strict sur tous les modèles
+- Branche : feature/issue-{N}-{slug}
+- Ouvre une draft PR quand la tâche est terminée
+
+## Structure des services
+```
+services/{service}/src/{service}/
+├── api/            # Handlers FastAPI (thin layer)
+├── application/    # Use cases (orchestration)
+├── domain/         # Entités, value objects, ports (ABCs)
+└── infrastructure/ # Adaptateurs AWS
+```
+
+## Ce que tu ne fais pas
+- Modifier infra/ sans instruction explicite
+- Appeler l'API Anthropic ou AWS réellement dans les tests
+- Committer sur main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# grading-cloud — CLAUDE.md
+
+## Identité du projet
+Pipeline de correction automatique de copies d'étudiants.
+Stack : Python 3.12 · FastAPI · AWS (Fargate + Lambda + DynamoDB + S3 + SQS)
+· Anthropic Batch API · CDK Python · uv workspaces
+
+## Architecture — règles absolues
+- Architecture hexagonale stricte. ZERO import AWS dans domain/ ou ports/.
+- `grading_shared` est le package partagé (uv workspace). Toute modification
+  des modèles domain impacte les 4 services — vérifie la rétrocompat.
+- Single-table DynamoDB : PK/SK explicites, pas de scan full-table.
+- Pydantic v2 strict partout : `model_config = ConfigDict(extra="forbid", strict=True)`.
+- SQS : publier l'événement pipeline APRÈS la mise à jour DynamoDB, jamais avant.
+- EventBridge Scheduler : une règle par batch actif, supprimée quand le batch se termine.
+
+## Agents Claude Code disponibles
+- `backend-dev`      — implémentation features (domain → application → infrastructure → api)
+- `test-writer`      — tests pytest après implémentation
+- `reviewer`         — review constructive + adversariale sur les fichiers produits
+- `shared-package`   — modifications grading_shared (impact cross-services)
+- `infra-dev`        — modifications CDK Python dans infra/
+
+## Stack de tests
+- Framework : pytest + pytest-asyncio
+- Mocks : `unittest.mock` ou `moto` pour AWS — jamais d'appels réels en test
+- Coverage cible : 80 % sur domain/ et application/, 60 % sur infrastructure/
+- Commande : `uv run pytest` depuis la racine du service concerné
+
+## Conventions de commit et branches
+- Branche : `feature/issue-{N}-{slug}` (ex: `feature/issue-7-create-exam`)
+- Commit : `{type}(#{N}): {description}` (ex: `feat(#7): add CreateExam use case`)
+- Types : feat | fix | test | refactor | infra | docs
+- Ne jamais committer directement sur main
+
+## Services et leur rôle
+- `exam-api` (Fargate)              : API FastAPI + orchestration pipeline + consommateur SQS
+- `spreadsheet-converter` (Lambda)  : xlsx/ods/numbers → JSON structuré
+- `batch-poller` (Lambda)           : polling statut batch Anthropic → résultats S3
+- `pdf-generator` (Lambda)          : Jinja2 + WeasyPrint → PDF
+
+## Fichiers à ne jamais modifier sans instruction explicite
+- `infra/`                       — utilise l'agent infra-dev
+- `shared/grading_shared/domain/` — utilise l'agent shared-package
+- `.github/workflows/`           — CI/CD
+
+## Context GitHub Actions
+- Crée toujours une branche, jamais de commit sur main
+- Formate les commentaires en GitHub-flavoured Markdown
+- Les secrets AWS ne sont pas disponibles — ne tente pas d'appels AWS réels

--- a/infra/app.py
+++ b/infra/app.py
@@ -3,18 +3,26 @@
 import aws_cdk as cdk
 
 from stacks.auth_stack import AuthStack
+from stacks.compute_stack import ComputeStack
 from stacks.storage_stack import StorageStack
 
 app = cdk.App()
+
+storage_stack = StorageStack(
+    app,
+    "GradingStorageStack",
+)
 
 AuthStack(
     app,
     "GradingAuthStack",
 )
 
-StorageStack(
+ComputeStack(
     app,
-    "GradingStorageStack",
+    "GradingComputeStack",
+    files_bucket=storage_stack.files_bucket,
+    grading_table=storage_stack.grading_table,
 )
 
 app.synth()

--- a/infra/stacks/compute_stack.py
+++ b/infra/stacks/compute_stack.py
@@ -1,0 +1,284 @@
+from aws_cdk import (
+    CfnOutput,
+    Duration,
+    Stack,
+    aws_dynamodb as dynamodb,
+    aws_ec2 as ec2,
+    aws_ecr as ecr,
+    aws_ecs as ecs,
+    aws_elasticloadbalancingv2 as elbv2,
+    aws_events as events,
+    aws_iam as iam,
+    aws_logs as logs,
+    aws_s3 as s3,
+    aws_sqs as sqs,
+)
+from constructs import Construct
+
+
+class ComputeStack(Stack):
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        files_bucket: s3.IBucket,
+        grading_table: dynamodb.ITable,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        self.exam_api_repository = ecr.Repository(
+            self,
+            "ExamApiRepository",
+            repository_name="exam-api",
+            image_scan_on_push=True,
+        )
+        self.spreadsheet_converter_repository = ecr.Repository(
+            self,
+            "SpreadsheetConverterRepository",
+            repository_name="spreadsheet-converter",
+            image_scan_on_push=True,
+        )
+        self.batch_poller_repository = ecr.Repository(
+            self,
+            "BatchPollerRepository",
+            repository_name="batch-poller",
+            image_scan_on_push=True,
+        )
+        self.pdf_generator_repository = ecr.Repository(
+            self,
+            "PdfGeneratorRepository",
+            repository_name="pdf-generator",
+            image_scan_on_push=True,
+        )
+
+        pipeline_dlq = sqs.Queue(
+            self,
+            "PipelineEventsDlq",
+            queue_name="grading-pipeline-events-dlq",
+            retention_period=Duration.days(14),
+            enforce_ssl=True,
+        )
+        pipeline_events_queue = sqs.Queue(
+            self,
+            "PipelineEventsQueue",
+            queue_name="grading-pipeline-events",
+            retention_period=Duration.days(4),
+            visibility_timeout=Duration.minutes(5),
+            dead_letter_queue=sqs.DeadLetterQueue(
+                max_receive_count=5,
+                queue=pipeline_dlq,
+            ),
+            enforce_ssl=True,
+        )
+
+        event_bus = events.EventBus(
+            self,
+            "GradingEventBus",
+            event_bus_name="grading-event-bus",
+        )
+
+        vpc = ec2.Vpc(
+            self,
+            "GradingVpc",
+            max_azs=2,
+            nat_gateways=0,
+        )
+        cluster = ecs.Cluster(
+            self,
+            "GradingCluster",
+            vpc=vpc,
+            cluster_name="grading-cluster",
+        )
+
+        task_definition = ecs.FargateTaskDefinition(
+            self,
+            "ExamApiTaskDefinition",
+            cpu=512,
+            memory_limit_mib=1024,
+        )
+        task_definition.add_container(
+            "ExamApiContainer",
+            image=ecs.ContainerImage.from_ecr_repository(self.exam_api_repository, "latest"),
+            container_name="exam-api",
+            logging=ecs.LogDrivers.aws_logs(
+                stream_prefix="exam-api",
+                log_retention=logs.RetentionDays.ONE_MONTH,
+            ),
+            environment={
+                "FILES_BUCKET_NAME": files_bucket.bucket_name,
+                "GRADING_TABLE_NAME": grading_table.table_name,
+                "PIPELINE_EVENTS_QUEUE_URL": pipeline_events_queue.queue_url,
+                "EVENT_BUS_NAME": event_bus.event_bus_name,
+            },
+            port_mappings=[ecs.PortMapping(container_port=8000)],
+        )
+
+        service = ecs.FargateService(
+            self,
+            "ExamApiService",
+            cluster=cluster,
+            task_definition=task_definition,
+            desired_count=1,
+            assign_public_ip=True,
+            service_name="exam-api",
+            vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PUBLIC),
+        )
+
+        alb = elbv2.ApplicationLoadBalancer(
+            self,
+            "ExamApiAlb",
+            vpc=vpc,
+            internet_facing=True,
+            load_balancer_name="grading-exam-api-alb",
+        )
+        listener = alb.add_listener("HttpListener", port=80, open=True)
+        listener.add_targets(
+            "ExamApiTargets",
+            port=8000,
+            targets=[service],
+            health_check=elbv2.HealthCheck(
+                path="/health",
+                healthy_http_codes="200-399",
+            ),
+        )
+
+        task_role = task_definition.task_role
+        task_role.add_to_principal_policy(
+            iam.PolicyStatement(
+                sid="S3Access",
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject",
+                    "s3:ListBucket",
+                ],
+                resources=[
+                    files_bucket.bucket_arn,
+                    files_bucket.arn_for_objects("*"),
+                ],
+            )
+        )
+        task_role.add_to_principal_policy(
+            iam.PolicyStatement(
+                sid="DynamoDbAccess",
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "dynamodb:BatchGetItem",
+                    "dynamodb:BatchWriteItem",
+                    "dynamodb:ConditionCheckItem",
+                    "dynamodb:DeleteItem",
+                    "dynamodb:GetItem",
+                    "dynamodb:PutItem",
+                    "dynamodb:Query",
+                    "dynamodb:TransactGetItems",
+                    "dynamodb:TransactWriteItems",
+                    "dynamodb:UpdateItem",
+                ],
+                resources=[
+                    grading_table.table_arn,
+                    f"{grading_table.table_arn}/index/*",
+                ],
+            )
+        )
+        task_role.add_to_principal_policy(
+            iam.PolicyStatement(
+                sid="SqsAccess",
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "sqs:ChangeMessageVisibility",
+                    "sqs:DeleteMessage",
+                    "sqs:GetQueueAttributes",
+                    "sqs:GetQueueUrl",
+                    "sqs:ReceiveMessage",
+                    "sqs:SendMessage",
+                ],
+                resources=[
+                    pipeline_events_queue.queue_arn,
+                    pipeline_dlq.queue_arn,
+                ],
+            )
+        )
+        task_role.add_to_principal_policy(
+            iam.PolicyStatement(
+                sid="SesAccess",
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "ses:SendEmail",
+                    "ses:SendRawEmail",
+                ],
+                resources=[
+                    f"arn:aws:ses:{self.region}:{self.account}:identity/*",
+                ],
+            )
+        )
+        task_role.add_to_principal_policy(
+            iam.PolicyStatement(
+                sid="EventBridgeAccess",
+                effect=iam.Effect.ALLOW,
+                actions=["events:PutEvents"],
+                resources=[event_bus.event_bus_arn],
+            )
+        )
+
+        CfnOutput(
+            self,
+            "ExamApiRepositoryUri",
+            value=self.exam_api_repository.repository_uri,
+            export_name="GradingExamApiRepositoryUri",
+        )
+        CfnOutput(
+            self,
+            "SpreadsheetConverterRepositoryUri",
+            value=self.spreadsheet_converter_repository.repository_uri,
+            export_name="GradingSpreadsheetConverterRepositoryUri",
+        )
+        CfnOutput(
+            self,
+            "BatchPollerRepositoryUri",
+            value=self.batch_poller_repository.repository_uri,
+            export_name="GradingBatchPollerRepositoryUri",
+        )
+        CfnOutput(
+            self,
+            "PdfGeneratorRepositoryUri",
+            value=self.pdf_generator_repository.repository_uri,
+            export_name="GradingPdfGeneratorRepositoryUri",
+        )
+        CfnOutput(
+            self,
+            "ExamApiAlbDnsName",
+            value=alb.load_balancer_dns_name,
+            export_name="GradingExamApiAlbDnsName",
+        )
+        CfnOutput(
+            self,
+            "ExamApiClusterName",
+            value=cluster.cluster_name,
+            export_name="GradingExamApiClusterName",
+        )
+        CfnOutput(
+            self,
+            "ExamApiServiceName",
+            value=service.service_name,
+            export_name="GradingExamApiServiceName",
+        )
+        CfnOutput(
+            self,
+            "PipelineEventsQueueUrl",
+            value=pipeline_events_queue.queue_url,
+            export_name="GradingPipelineEventsQueueUrl",
+        )
+        CfnOutput(
+            self,
+            "PipelineEventsQueueArn",
+            value=pipeline_events_queue.queue_arn,
+            export_name="GradingPipelineEventsQueueArn",
+        )
+        CfnOutput(
+            self,
+            "EventBusName",
+            value=event_bus.event_bus_name,
+            export_name="GradingEventBusName",
+        )


### PR DESCRIPTION
## Summary
- Add a new `ComputeStack` provisioning four ECR repositories: `exam-api`, `spreadsheet-converter`, `batch-poller`, and `pdf-generator`.
- Provision ECS Fargate compute with a dedicated VPC, ECS cluster, task definition, and service fronted by an internet-facing ALB.
- Scope ECS task IAM permissions to least privilege for S3, DynamoDB, SQS, SES, and EventBridge only.

## Test plan
- [x] Run `uv run cdk synth` from `infra/`.
- [x] Run `cdk diff GradingComputeStack` against target account.
- [x] Deploy `GradingComputeStack` in sandbox and validate ALB health checks and task startup.

Closes #4

Made with [Cursor](https://cursor.com)