### PR TITLE
fix: prevent silent permission denials in Claude review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,6 +25,19 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          settings: |
+            {
+              "permissionMode": "acceptEdits",
+              "permissions": {
+                "allow": [
+                  "Read",
+                  "Glob",
+                  "Grep",
+                  "Bash(git *)",
+                  "Bash(gh *)"
+                ]
+              }
+            }
           prompt: |
             Tu es un tech lead senior qui review une PR sur un projet
             Python/FastAPI avec architecture hexagonale sur AWS.


### PR DESCRIPTION
## Summary
- add explicit Claude Code tool permissions to `.github/workflows/claude-review.yml`
- allow read/search plus `git`/`gh` bash commands needed during autonomous PR review runs
- keep workflow behavior unchanged otherwise; only permission configuration is updated

## Test plan
- [ ] Open or update a non-draft PR to trigger `Claude Code Review`
- [ ] Confirm workflow completes and review comments are posted as expected
- [ ] Verify no unexpected file edits or branch operations are performed by the workflow

Made with [Cursor](https://cursor.com)