### PR TITLE
docs(#58): enforce async-first rule across agent configs

### DIFF
--- a/.claude/agents/backend-dev.md
+++ b/.claude/agents/backend-dev.md
@@ -18,6 +18,7 @@ Tu es un ingénieur backend senior Python/FastAPI/AWS.
 - Pydantic v2 strict : ConfigDict(extra="forbid", strict=True)
 - Les ports sont des ABCs dans grading_shared/ports/
 - Si tu dois modifier grading_shared → utilise l'agent shared-package à la place
+- Async-first obligatoire : écris le code en `async def` / `await` avec des co-routines dès que possible ; n'utilise pas de librairie synchrone si un équivalent async existe
 
 ## Ce que tu ne fais pas
 - Écrire les tests (c'est test-writer)

--- a/.claude/agents/infra-dev.md
+++ b/.claude/agents/infra-dev.md
@@ -13,6 +13,7 @@ Tu es un architecte AWS senior. Tu modifies uniquement infra/.
 3. **Retry policy** — Lambda visibility timeout > durée max d'exécution
 4. **Secrets** — pas de valeur hardcodée, SSM Parameter Store ou Secrets Manager
 5. **Coût** — Lambda timeout calibré, Fargate sizing justifié
+6. **Async-first** — tout code Python modifié doit privilégier `async def` / `await` et les co-routines ; éviter les libs synchrones quand un équivalent async existe
 
 ## Après chaque modification
 Lance `cd infra && uv run cdk synth` pour vérifier la syntaxe CDK.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -11,7 +11,7 @@ Tu es un tech lead senior doublé d'un ingénieur hostile. Tu fais les deux.
 Priorités :
 1. **Sécurité** — injection, credentials exposés, IAM trop large
 2. **Architecture** — violation hexagonale (import AWS dans domain ?), couplage fort
-3. **Correctness** — logique métier incorrecte, edge cases ignorés
+3. **Correctness** — logique métier incorrecte, edge cases ignorés, non-respect de l'async-first (`async def`/`await`, co-routines, et absence de libs synchrones si un équivalent async existe)
 4. **Performance** — N+1 DynamoDB, scan full-table, Lambda cold start inutile
 5. **Tests** — coverage insuffisant, tests qui ne testent rien
 6. **Style** — seulement si 1-5 sont OK

--- a/.claude/agents/shared-package.md
+++ b/.claude/agents/shared-package.md
@@ -22,3 +22,4 @@ Tu es l'ingénieur responsable du package partagé grading_shared.
 - Zéro import AWS dans domain/ ou ports/ — même règle que partout
 - Un changement de port ABC = vérifier les 4 implémentations dans infrastructure/
 - Ne jamais supprimer un champ Pydantic sans migration (passer par Optional d'abord)
+- Async-first obligatoire : tout code Python doit être écrit en `async def` / `await` avec co-routines dès que possible ; n'utilise pas de librairie synchrone s'il existe un équivalent async

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -23,3 +23,4 @@ Tu es un ingénieur QA senior spécialisé pytest/Python.
 - Fixtures dans conftest.py, pas dans les fichiers de test
 - Un test = une assertion principale
 - Coverage cible : 80% sur domain/ et application/
+- Async-first : privilégie des tests async (`async def`, `await`, `pytest-asyncio`) et n'introduis pas de librairies synchrones quand l'équivalent async existe

--- a/.cursorrules
+++ b/.cursorrules
@@ -6,6 +6,7 @@
 - Utiliser Pydantic v2 ConfigDict(extra="forbid", strict=True)
 - Vérifier que les nouveaux ports sont des ABCs dans grading_shared/ports/
 - Types explicites partout (pas de `Any` sauf cas justifié avec commentaire)
+- Écrire le code en async-first : `async def` / `await` et co-routines dès que possible ; éviter les librairies synchrones quand un équivalent async existe
 
 ## Jamais
 

--- a/Agent.md
+++ b/Agent.md
@@ -35,6 +35,7 @@ spécialisés et s'appellent en séquence. Cloud Agents font tout d'un coup.)
 ## Conventions obligatoires
 - Architecture hexagonale : domain/ = Python pur, zéro import AWS
 - Pydantic v2 strict sur tous les modèles
+- Async-first : tout code applicatif doit utiliser `async def` / `await` et les co-routines dès qu'une alternative asynchrone existe (éviter les libs synchrones quand l'équivalent async est disponible)
 - Branche : feature/issue-{N}-{slug}
 - Ouvre une draft PR quand la tâche est terminée
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,9 @@ Stack : Python 3.12 · FastAPI · AWS (Fargate + Lambda + DynamoDB + S3 + SQS)
 - Architecture hexagonale stricte. ZERO import AWS dans domain/ ou ports/.
 - `grading_shared` est le package partagé (uv workspace). Toute modification
   des modèles domain impacte les 4 services — vérifie la rétrocompat.
+- Async-first obligatoire : tout nouveau code doit être écrit en asynchrone
+  (`async def` / `await`) dès qu'un équivalent async existe ; évite les
+  librairies synchrones quand une alternative asynchrone est disponible.
 - Single-table DynamoDB : PK/SK explicites, pas de scan full-table.
 - Pydantic v2 strict partout : `model_config = ConfigDict(extra="forbid", strict=True)`.
 - SQS : publier l'événement pipeline APRÈS la mise à jour DynamoDB, jamais avant.


### PR DESCRIPTION
Add a consistent async-first requirement to agent and project guidance so new Python code uses async def/await and avoids sync libraries when async alternatives exist.