### PR TITLE
feat(#57): move student-exam scope authorization to DynamoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Two roles, enforced by Cognito groups and FastAPI dependencies:
 | **Teacher** | Create exams, upload config + spreadsheets, manage student roster, trigger pipeline, view all results for their exams, download all PDFs |
 | **Student** | Upload their own spreadsheet, view their own grade breakdown, download their own PDF |
 
-Students are scoped at the JWT level: the Cognito token carries `custom:role=student` and `custom:exam_id`. Every student-facing endpoint validates that the requested resource matches the token's subject (`sub`).
+Students are scoped by DynamoDB mappings: student-facing endpoints require a JWT with `custom:role=student` and a matching `sub`, then validate that `PK=EXAM#{exam_id}` and `SK=STUDENT#{sub}` exists.
 
 ---
 

--- a/infra/stacks/auth_stack.py
+++ b/infra/stacks/auth_stack.py
@@ -23,11 +23,6 @@ class AuthStack(Stack):
                     max_len=7,
                     mutable=True,
                 ),
-                "exam_id": cognito.StringAttribute(
-                    min_len=1,
-                    max_len=128,
-                    mutable=True,
-                ),
             },
         )
 

--- a/services/exam-api/exam_api/api/invite_router.py
+++ b/services/exam-api/exam_api/api/invite_router.py
@@ -52,7 +52,6 @@ class CurrentStudent(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
 
     student_id: str
-    exam_id: str
 
 
 class StudentScopeResponse(BaseModel):
@@ -130,18 +129,12 @@ def get_current_student(
             detail="Only students can access this route.",
         )
     student_id = claims.get("sub")
-    exam_id = claims.get("custom:exam_id")
     if not isinstance(student_id, str) or not student_id:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing student identifier in JWT claims.",
         )
-    if not isinstance(exam_id, str) or not exam_id:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Missing exam scope in JWT claims.",
-        )
-    return CurrentStudent(student_id=student_id, exam_id=exam_id)
+    return CurrentStudent(student_id=student_id)
 
 
 def get_student_invite_service(request: Request) -> StudentInviteServicePort:
@@ -252,7 +245,7 @@ async def get_student_scope(
         StudentScopeRepositoryPort, Depends(get_student_scope_repository)
     ],
 ) -> StudentScopeResponse:
-    if current_student.exam_id != exam_id or current_student.student_id != student_id:
+    if current_student.student_id != student_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Student token does not match requested resource.",

--- a/services/exam-api/exam_api/api/invite_router.py
+++ b/services/exam-api/exam_api/api/invite_router.py
@@ -9,7 +9,6 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from httpx import HTTPError
 from jose import JWTError
 from pydantic import BaseModel, ConfigDict, EmailStr
-from starlette.concurrency import run_in_threadpool
 
 from exam_api.application.invite_student import (
     InviteStudentCommand,
@@ -201,8 +200,7 @@ async def invite_student(
     use_case: Annotated[InviteStudentUseCase, Depends(provide_invite_use_case)],
 ) -> InviteStudentResponse:
     try:
-        result = await run_in_threadpool(
-            use_case.execute,
+        result = await use_case.execute(
             InviteStudentCommand(
                 exam_id=exam_id,
                 student_id=student_id,
@@ -250,8 +248,7 @@ async def get_student_scope(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Student token does not match requested resource.",
         )
-    student_scope = await run_in_threadpool(
-        student_scope_repository.get_student_scope,
+    student_scope = await student_scope_repository.get_student_scope(
         exam_id=exam_id,
         student_sub=student_id,
     )

--- a/services/exam-api/exam_api/application/invite_student.py
+++ b/services/exam-api/exam_api/application/invite_student.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from grading_shared.domain.exam import Exam
 from grading_shared.ports import ExamRepositoryPort
 from grading_shared.domain.models import StrictModel
@@ -10,7 +12,6 @@ from pydantic import EmailStr
 from exam_api.domain.errors import (
     ExamNotFoundError,
     ExamOwnershipError,
-    StudentExamScopeConflictError,
 )
 from exam_api.domain.student import Student
 from exam_api.ports.student_scope_repository_port import StudentScopeRepositoryPort
@@ -40,23 +41,12 @@ class InviteStudentUseCase:
         self._exam_repository = exam_repository
         self._student_scope_repository = student_scope_repository
 
-    def execute(self, command: InviteStudentCommand) -> InviteStudentResult:
-        exam = self._load_owned_exam(
+    async def execute(self, command: InviteStudentCommand) -> InviteStudentResult:
+        exam = await self._load_owned_exam(
             exam_id=command.exam_id,
             teacher_id=command.teacher_id,
         )
-        existing_student_sub = self._invite_service.lookup_student_sub_by_email(
-            student_email=str(command.student_email)
-        )
-        if existing_student_sub is not None:
-            existing_exam_id = self._student_scope_repository.get_exam_id_for_student_sub(
-                student_sub=existing_student_sub
-            )
-            if existing_exam_id is not None and existing_exam_id != exam.exam_id:
-                raise StudentExamScopeConflictError(
-                    "Student account is already scoped to another exam."
-                )
-        invite_result = self._invite_service.invite_student(
+        invite_result = await self._invite_service.invite_student(
             student_email=str(command.student_email),
             exam_id=exam.exam_id,
         )
@@ -65,7 +55,7 @@ class InviteStudentUseCase:
             exam_id=exam.exam_id,
             email=command.student_email,
         )
-        self._student_scope_repository.upsert_student_scope(
+        await self._student_scope_repository.upsert_student_scope(
             student=student,
             teacher_id=command.teacher_id,
             external_student_id=command.student_id,
@@ -75,8 +65,8 @@ class InviteStudentUseCase:
             re_invited=invite_result.already_existed,
         )
 
-    def _load_owned_exam(self, *, exam_id: str, teacher_id: str) -> Exam:
-        exam = self._exam_repository.get_exam(exam_id=exam_id)
+    async def _load_owned_exam(self, *, exam_id: str, teacher_id: str) -> Exam:
+        exam = await asyncio.to_thread(self._exam_repository.get_exam, exam_id=exam_id)
         if exam is None:
             raise ExamNotFoundError(f"Exam {exam_id} not found.")
         if exam.teacher_id != teacher_id:

--- a/services/exam-api/exam_api/application/invite_student.py
+++ b/services/exam-api/exam_api/application/invite_student.py
@@ -45,6 +45,17 @@ class InviteStudentUseCase:
             exam_id=command.exam_id,
             teacher_id=command.teacher_id,
         )
+        existing_student_sub = self._invite_service.lookup_student_sub_by_email(
+            student_email=str(command.student_email)
+        )
+        if existing_student_sub is not None:
+            existing_exam_id = self._student_scope_repository.get_exam_id_for_student_sub(
+                student_sub=existing_student_sub
+            )
+            if existing_exam_id is not None and existing_exam_id != exam.exam_id:
+                raise StudentExamScopeConflictError(
+                    "Student account is already scoped to another exam."
+                )
         invite_result = self._invite_service.invite_student(
             student_email=str(command.student_email),
             exam_id=exam.exam_id,
@@ -54,13 +65,6 @@ class InviteStudentUseCase:
             exam_id=exam.exam_id,
             email=command.student_email,
         )
-        existing_exam_id = self._student_scope_repository.get_exam_id_for_student_sub(
-            student_sub=student.student_id
-        )
-        if existing_exam_id is not None and existing_exam_id != exam.exam_id:
-            raise StudentExamScopeConflictError(
-                "Student account is already scoped to another exam."
-            )
         self._student_scope_repository.upsert_student_scope(
             student=student,
             teacher_id=command.teacher_id,

--- a/services/exam-api/exam_api/application/invite_student.py
+++ b/services/exam-api/exam_api/application/invite_student.py
@@ -7,7 +7,11 @@ from grading_shared.ports import ExamRepositoryPort
 from grading_shared.domain.models import StrictModel
 from pydantic import EmailStr
 
-from exam_api.domain.errors import ExamNotFoundError, ExamOwnershipError
+from exam_api.domain.errors import (
+    ExamNotFoundError,
+    ExamOwnershipError,
+    StudentExamScopeConflictError,
+)
 from exam_api.domain.student import Student
 from exam_api.ports.student_scope_repository_port import StudentScopeRepositoryPort
 from exam_api.ports.student_invite_port import StudentInviteServicePort
@@ -50,6 +54,13 @@ class InviteStudentUseCase:
             exam_id=exam.exam_id,
             email=command.student_email,
         )
+        existing_exam_id = self._student_scope_repository.get_exam_id_for_student_sub(
+            student_sub=student.student_id
+        )
+        if existing_exam_id is not None and existing_exam_id != exam.exam_id:
+            raise StudentExamScopeConflictError(
+                "Student account is already scoped to another exam."
+            )
         self._student_scope_repository.upsert_student_scope(
             student=student,
             teacher_id=command.teacher_id,

--- a/services/exam-api/exam_api/infrastructure/dynamodb_invite_repository.py
+++ b/services/exam-api/exam_api/infrastructure/dynamodb_invite_repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from typing import Any
 
@@ -77,8 +78,18 @@ class DynamoDbInviteRepository(ExamRepositoryPort, StudentScopeRepositoryPort):
             }
         )
 
-    def upsert_student_scope(
+    async def upsert_student_scope(
         self, *, student: Student, teacher_id: str, external_student_id: str
+    ) -> None:
+        await asyncio.to_thread(
+            self._upsert_student_scope_sync,
+            student,
+            teacher_id,
+            external_student_id,
+        )
+
+    def _upsert_student_scope_sync(
+        self, student: Student, teacher_id: str, external_student_id: str
     ) -> None:
         now_iso = datetime.now(UTC).isoformat()
         try:
@@ -146,7 +157,10 @@ class DynamoDbInviteRepository(ExamRepositoryPort, StudentScopeRepositoryPort):
                 ) from err
             raise
 
-    def get_student_scope(self, *, exam_id: str, student_sub: str) -> Student | None:
+    async def get_student_scope(self, *, exam_id: str, student_sub: str) -> Student | None:
+        return await asyncio.to_thread(self._get_student_scope_sync, exam_id, student_sub)
+
+    def _get_student_scope_sync(self, exam_id: str, student_sub: str) -> Student | None:
         response = self._table.get_item(
             Key={
                 "PK": f"EXAM#{exam_id}",
@@ -161,22 +175,6 @@ class DynamoDbInviteRepository(ExamRepositoryPort, StudentScopeRepositoryPort):
         if not isinstance(email, str) or not email:
             return None
         return Student(student_id=student_sub, exam_id=exam_id, email=email)
-
-    def get_exam_id_for_student_sub(self, *, student_sub: str) -> str | None:
-        response = self._table.get_item(
-            Key={
-                "PK": f"STUDENT#{student_sub}",
-                "SK": "SCOPE",
-            },
-            ConsistentRead=True,
-        )
-        item = response.get("Item")
-        if not isinstance(item, dict):
-            return None
-        exam_id = item.get("exam_id")
-        if not isinstance(exam_id, str) or not exam_id:
-            return None
-        return exam_id
 
     @staticmethod
     def _is_scope_conflict_error(err: ClientError) -> bool:

--- a/services/exam-api/exam_api/infrastructure/dynamodb_invite_repository.py
+++ b/services/exam-api/exam_api/infrastructure/dynamodb_invite_repository.py
@@ -6,11 +6,13 @@ from datetime import UTC, datetime
 from typing import Any
 
 import boto3  # type: ignore[import-untyped]
+from botocore.exceptions import ClientError  # type: ignore[import-untyped]
 
 from grading_shared.domain.exam import Exam, ExamStatus
 from grading_shared.domain.models import NotationPayload
 from grading_shared.ports import ExamRepositoryPort
 
+from exam_api.domain.errors import StudentExamScopeConflictError
 from exam_api.domain.student import Student
 from exam_api.ports.student_scope_repository_port import StudentScopeRepositoryPort
 
@@ -18,7 +20,9 @@ from exam_api.ports.student_scope_repository_port import StudentScopeRepositoryP
 class DynamoDbInviteRepository(ExamRepositoryPort, StudentScopeRepositoryPort):
     def __init__(self, *, table_name: str, dynamodb_resource: Any | None = None) -> None:
         resource = dynamodb_resource or boto3.resource("dynamodb")
+        self._table_name = table_name
         self._table = resource.Table(table_name)
+        self._dynamodb_client = resource.meta.client
 
     def get_exam(self, *, exam_id: str) -> Exam | None:
         response = self._table.get_item(
@@ -77,50 +81,70 @@ class DynamoDbInviteRepository(ExamRepositoryPort, StudentScopeRepositoryPort):
         self, *, student: Student, teacher_id: str, external_student_id: str
     ) -> None:
         now_iso = datetime.now(UTC).isoformat()
-        self._table.update_item(
-            Key={
-                "PK": f"EXAM#{student.exam_id}",
-                "SK": f"STUDENT#{student.student_id}",
-            },
-            UpdateExpression=(
-                "SET teacher_id = :teacher_id, "
-                "student_id = :student_id, "
-                "external_student_id = :external_student_id, "
-                "email = :email, "
-                "updated_at = :updated_at, "
-                "invited_at = if_not_exists(invited_at, :invited_at)"
-            ),
-            ExpressionAttributeValues={
-                ":teacher_id": teacher_id,
-                ":student_id": student.student_id,
-                ":external_student_id": external_student_id,
-                ":email": str(student.email),
-                ":updated_at": now_iso,
-                ":invited_at": now_iso,
-            },
-        )
-        self._table.update_item(
-            Key={
-                "PK": f"STUDENT#{student.student_id}",
-                "SK": "SCOPE",
-            },
-            UpdateExpression=(
-                "SET exam_id = :exam_id, "
-                "teacher_id = :teacher_id, "
-                "external_student_id = :external_student_id, "
-                "email = :email, "
-                "updated_at = :updated_at, "
-                "invited_at = if_not_exists(invited_at, :invited_at)"
-            ),
-            ExpressionAttributeValues={
-                ":exam_id": student.exam_id,
-                ":teacher_id": teacher_id,
-                ":external_student_id": external_student_id,
-                ":email": str(student.email),
-                ":updated_at": now_iso,
-                ":invited_at": now_iso,
-            },
-        )
+        try:
+            self._dynamodb_client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Update": {
+                            "TableName": self._table_name,
+                            "Key": {
+                                "PK": {"S": f"EXAM#{student.exam_id}"},
+                                "SK": {"S": f"STUDENT#{student.student_id}"},
+                            },
+                            "UpdateExpression": (
+                                "SET teacher_id = :teacher_id, "
+                                "student_id = :student_id, "
+                                "external_student_id = :external_student_id, "
+                                "email = :email, "
+                                "updated_at = :updated_at, "
+                                "invited_at = if_not_exists(invited_at, :invited_at)"
+                            ),
+                            "ExpressionAttributeValues": {
+                                ":teacher_id": {"S": teacher_id},
+                                ":student_id": {"S": student.student_id},
+                                ":external_student_id": {"S": external_student_id},
+                                ":email": {"S": str(student.email)},
+                                ":updated_at": {"S": now_iso},
+                                ":invited_at": {"S": now_iso},
+                            },
+                        }
+                    },
+                    {
+                        "Update": {
+                            "TableName": self._table_name,
+                            "Key": {
+                                "PK": {"S": f"STUDENT#{student.student_id}"},
+                                "SK": {"S": "SCOPE"},
+                            },
+                            "UpdateExpression": (
+                                "SET exam_id = :exam_id, "
+                                "teacher_id = :teacher_id, "
+                                "external_student_id = :external_student_id, "
+                                "email = :email, "
+                                "updated_at = :updated_at, "
+                                "invited_at = if_not_exists(invited_at, :invited_at)"
+                            ),
+                            "ConditionExpression": (
+                                "attribute_not_exists(exam_id) OR exam_id = :exam_id"
+                            ),
+                            "ExpressionAttributeValues": {
+                                ":exam_id": {"S": student.exam_id},
+                                ":teacher_id": {"S": teacher_id},
+                                ":external_student_id": {"S": external_student_id},
+                                ":email": {"S": str(student.email)},
+                                ":updated_at": {"S": now_iso},
+                                ":invited_at": {"S": now_iso},
+                            },
+                        }
+                    },
+                ]
+            )
+        except ClientError as err:
+            if self._is_scope_conflict_error(err):
+                raise StudentExamScopeConflictError(
+                    "Student account is already scoped to another exam."
+                ) from err
+            raise
 
     def get_student_scope(self, *, exam_id: str, student_sub: str) -> Student | None:
         response = self._table.get_item(
@@ -153,3 +177,20 @@ class DynamoDbInviteRepository(ExamRepositoryPort, StudentScopeRepositoryPort):
         if not isinstance(exam_id, str) or not exam_id:
             return None
         return exam_id
+
+    @staticmethod
+    def _is_scope_conflict_error(err: ClientError) -> bool:
+        code = str(err.response.get("Error", {}).get("Code", ""))
+        if code == "ConditionalCheckFailedException":
+            return True
+        if code != "TransactionCanceledException":
+            return False
+        reasons = err.response.get("CancellationReasons", [])
+        if not isinstance(reasons, list):
+            return False
+        for reason in reasons:
+            if not isinstance(reason, dict):
+                continue
+            if reason.get("Code") == "ConditionalCheckFailed":
+                return True
+        return False

--- a/services/exam-api/exam_api/infrastructure/dynamodb_invite_repository.py
+++ b/services/exam-api/exam_api/infrastructure/dynamodb_invite_repository.py
@@ -99,6 +99,28 @@ class DynamoDbInviteRepository(ExamRepositoryPort, StudentScopeRepositoryPort):
                 ":invited_at": now_iso,
             },
         )
+        self._table.update_item(
+            Key={
+                "PK": f"STUDENT#{student.student_id}",
+                "SK": "SCOPE",
+            },
+            UpdateExpression=(
+                "SET exam_id = :exam_id, "
+                "teacher_id = :teacher_id, "
+                "external_student_id = :external_student_id, "
+                "email = :email, "
+                "updated_at = :updated_at, "
+                "invited_at = if_not_exists(invited_at, :invited_at)"
+            ),
+            ExpressionAttributeValues={
+                ":exam_id": student.exam_id,
+                ":teacher_id": teacher_id,
+                ":external_student_id": external_student_id,
+                ":email": str(student.email),
+                ":updated_at": now_iso,
+                ":invited_at": now_iso,
+            },
+        )
 
     def get_student_scope(self, *, exam_id: str, student_sub: str) -> Student | None:
         response = self._table.get_item(
@@ -115,3 +137,19 @@ class DynamoDbInviteRepository(ExamRepositoryPort, StudentScopeRepositoryPort):
         if not isinstance(email, str) or not email:
             return None
         return Student(student_id=student_sub, exam_id=exam_id, email=email)
+
+    def get_exam_id_for_student_sub(self, *, student_sub: str) -> str | None:
+        response = self._table.get_item(
+            Key={
+                "PK": f"STUDENT#{student_sub}",
+                "SK": "SCOPE",
+            },
+            ConsistentRead=True,
+        )
+        item = response.get("Item")
+        if not isinstance(item, dict):
+            return None
+        exam_id = item.get("exam_id")
+        if not isinstance(exam_id, str) or not exam_id:
+            return None
+        return exam_id

--- a/services/exam-api/exam_api/infrastructure/dynamodb_invite_repository.py
+++ b/services/exam-api/exam_api/infrastructure/dynamodb_invite_repository.py
@@ -178,9 +178,8 @@ class DynamoDbInviteRepository(ExamRepositoryPort, StudentScopeRepositoryPort):
 
     @staticmethod
     def _is_scope_conflict_error(err: ClientError) -> bool:
+        # transact_write_items: conditional failures use TransactionCanceledException + CancellationReasons.
         code = str(err.response.get("Error", {}).get("Code", ""))
-        if code == "ConditionalCheckFailedException":
-            return True
         if code != "TransactionCanceledException":
             return False
         reasons = err.response.get("CancellationReasons", [])

--- a/services/exam-api/exam_api/infrastructure/student_invite_adapter.py
+++ b/services/exam-api/exam_api/infrastructure/student_invite_adapter.py
@@ -87,6 +87,18 @@ class CognitoSesStudentInviteAdapter(StudentInviteServicePort):
             already_existed=already_existed,
         )
 
+    def lookup_student_sub_by_email(self, *, student_email: str) -> str | None:
+        try:
+            response = self._cognito.admin_get_user(
+                UserPoolId=self._user_pool_id,
+                Username=student_email,
+            )
+        except ClientError as err:
+            if self._extract_error_code(err) == "UserNotFoundException":
+                return None
+            raise
+        return self._extract_user_sub(response, student_email)
+
     def _send_invitation_email(
         self,
         *,

--- a/services/exam-api/exam_api/infrastructure/student_invite_adapter.py
+++ b/services/exam-api/exam_api/infrastructure/student_invite_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import secrets
 import string
 from typing import Any
@@ -28,12 +29,19 @@ class CognitoSesStudentInviteAdapter(StudentInviteServicePort):
         self._cognito = cognito_client or boto3.client("cognito-idp")
         self._ses = ses_client or boto3.client("ses")
 
-    def invite_student(
+    async def invite_student(
         self,
         *,
         student_email: str,
         exam_id: str,
     ) -> InviteStudentResult:
+        return await asyncio.to_thread(
+            self._invite_student_sync,
+            student_email,
+            exam_id,
+        )
+
+    def _invite_student_sync(self, student_email: str, exam_id: str) -> InviteStudentResult:
         temporary_password = self._generate_temporary_password()
         already_existed = False
         try:
@@ -86,18 +94,6 @@ class CognitoSesStudentInviteAdapter(StudentInviteServicePort):
             cognito_sub=cognito_sub,
             already_existed=already_existed,
         )
-
-    def lookup_student_sub_by_email(self, *, student_email: str) -> str | None:
-        try:
-            response = self._cognito.admin_get_user(
-                UserPoolId=self._user_pool_id,
-                Username=student_email,
-            )
-        except ClientError as err:
-            if self._extract_error_code(err) == "UserNotFoundException":
-                return None
-            raise
-        return self._extract_user_sub(response, student_email)
 
     def _send_invitation_email(
         self,

--- a/services/exam-api/exam_api/infrastructure/student_invite_adapter.py
+++ b/services/exam-api/exam_api/infrastructure/student_invite_adapter.py
@@ -9,7 +9,6 @@ from typing import Any
 import boto3  # type: ignore[import-untyped]
 from botocore.exceptions import ClientError  # type: ignore[import-untyped]
 
-from exam_api.domain.errors import StudentExamScopeConflictError
 from exam_api.ports.student_invite_port import InviteStudentResult, StudentInviteServicePort
 
 
@@ -47,7 +46,6 @@ class CognitoSesStudentInviteAdapter(StudentInviteServicePort):
                     {"Name": "email", "Value": student_email},
                     {"Name": "email_verified", "Value": "true"},
                     {"Name": "custom:role", "Value": "student"},
-                    {"Name": "custom:exam_id", "Value": exam_id},
                 ],
             )
             cognito_sub = self._extract_user_sub(response.get("User", {}), student_email)
@@ -59,14 +57,6 @@ class CognitoSesStudentInviteAdapter(StudentInviteServicePort):
                 UserPoolId=self._user_pool_id,
                 Username=student_email,
             )
-            existing_exam_id = self._extract_user_attribute(
-                existing_user,
-                "custom:exam_id",
-            )
-            if existing_exam_id and existing_exam_id != exam_id:
-                raise StudentExamScopeConflictError(
-                    "Student account is already scoped to another exam."
-                )
             self._cognito.admin_update_user_attributes(
                 UserPoolId=self._user_pool_id,
                 Username=student_email,
@@ -129,21 +119,6 @@ class CognitoSesStudentInviteAdapter(StudentInviteServicePort):
                 },
             },
         )
-
-    @staticmethod
-    def _extract_user_attribute(user_payload: dict[str, Any], name: str) -> str | None:
-        attributes = user_payload.get("UserAttributes") or user_payload.get("Attributes", [])
-        if not isinstance(attributes, list):
-            return None
-        for attribute in attributes:
-            if not isinstance(attribute, dict):
-                continue
-            if attribute.get("Name") != name:
-                continue
-            value = attribute.get("Value")
-            if isinstance(value, str) and value:
-                return value
-        return None
 
     @staticmethod
     def _extract_user_sub(user_payload: dict[str, Any], student_email: str) -> str:

--- a/services/exam-api/exam_api/ports/student_invite_port.py
+++ b/services/exam-api/exam_api/ports/student_invite_port.py
@@ -16,10 +16,7 @@ class InviteStudentResult(StrictModel):
 
 @runtime_checkable
 class StudentInviteServicePort(Protocol):
-    def lookup_student_sub_by_email(self, *, student_email: str) -> str | None:
-        """Return Cognito subject for an existing account, else None."""
-
-    def invite_student(
+    async def invite_student(
         self,
         *,
         student_email: str,

--- a/services/exam-api/exam_api/ports/student_invite_port.py
+++ b/services/exam-api/exam_api/ports/student_invite_port.py
@@ -16,6 +16,9 @@ class InviteStudentResult(StrictModel):
 
 @runtime_checkable
 class StudentInviteServicePort(Protocol):
+    def lookup_student_sub_by_email(self, *, student_email: str) -> str | None:
+        """Return Cognito subject for an existing account, else None."""
+
     def invite_student(
         self,
         *,

--- a/services/exam-api/exam_api/ports/student_invite_port.py
+++ b/services/exam-api/exam_api/ports/student_invite_port.py
@@ -26,7 +26,7 @@ class StudentInviteServicePort(Protocol):
 
         - If the student already exists in Cognito: resend the email, do NOT recreate account.
         - Cognito user must be added to the `students` group.
-        - Cognito custom attributes: `custom:role=student`, `custom:exam_id=<exam_id>`.
+        - Cognito custom attributes: `custom:role=student`.
         - TODO(#10): decide on MessageAction=SUPPRESS + custom SES email vs. Cognito built-in.
         """
         ...

--- a/services/exam-api/exam_api/ports/student_scope_repository_port.py
+++ b/services/exam-api/exam_api/ports/student_scope_repository_port.py
@@ -16,3 +16,6 @@ class StudentScopeRepositoryPort(Protocol):
 
     def get_student_scope(self, *, exam_id: str, student_sub: str) -> Student | None:
         """Load a student scope record by exam and Cognito subject."""
+
+    def get_exam_id_for_student_sub(self, *, student_sub: str) -> str | None:
+        """Load the exam scope currently bound to a Cognito student subject."""

--- a/services/exam-api/exam_api/ports/student_scope_repository_port.py
+++ b/services/exam-api/exam_api/ports/student_scope_repository_port.py
@@ -9,13 +9,10 @@ from exam_api.domain.student import Student
 
 @runtime_checkable
 class StudentScopeRepositoryPort(Protocol):
-    def upsert_student_scope(
+    async def upsert_student_scope(
         self, *, student: Student, teacher_id: str, external_student_id: str
     ) -> None:
         """Persist student ownership scope for downstream authorization checks."""
 
-    def get_student_scope(self, *, exam_id: str, student_sub: str) -> Student | None:
+    async def get_student_scope(self, *, exam_id: str, student_sub: str) -> Student | None:
         """Load a student scope record by exam and Cognito subject."""
-
-    def get_exam_id_for_student_sub(self, *, student_sub: str) -> str | None:
-        """Load the exam scope currently bound to a Cognito student subject."""

--- a/services/exam-api/tests/test_dynamodb_invite_repository.py
+++ b/services/exam-api/tests/test_dynamodb_invite_repository.py
@@ -58,7 +58,14 @@ def test_upsert_student_scope_writes_student_item() -> None:
         external_student_id="roster-17",
     )
 
-    call_kwargs = table.update_item.call_args.kwargs
+    first_call_kwargs = table.update_item.call_args_list[0].kwargs
+    second_call_kwargs = table.update_item.call_args_list[1].kwargs
+    assert table.update_item.call_count == 2
+    assert second_call_kwargs["Key"]["PK"] == "STUDENT#student-sub-1"
+    assert second_call_kwargs["Key"]["SK"] == "SCOPE"
+    assert second_call_kwargs["ExpressionAttributeValues"][":exam_id"] == "exam-1"
+
+    call_kwargs = first_call_kwargs
     assert call_kwargs["Key"]["PK"] == "EXAM#exam-1"
     assert call_kwargs["Key"]["SK"] == "STUDENT#student-sub-1"
     assert "if_not_exists(invited_at, :invited_at)" in call_kwargs["UpdateExpression"]
@@ -89,6 +96,27 @@ def test_get_student_scope_returns_student_record() -> None:
     assert student.student_id == "student-sub-1"
     assert student.exam_id == "exam-1"
     assert str(student.email) == "student@example.com"
+
+
+def test_get_exam_id_for_student_sub_returns_exam_id() -> None:
+    table = Mock()
+    table.get_item.return_value = {
+        "Item": {
+            "PK": "STUDENT#student-sub-1",
+            "SK": "SCOPE",
+            "exam_id": "exam-1",
+        }
+    }
+    dynamodb = Mock()
+    dynamodb.Table.return_value = table
+    repository = DynamoDbInviteRepository(
+        table_name="grading-table",
+        dynamodb_resource=dynamodb,
+    )
+
+    exam_id = repository.get_exam_id_for_student_sub(student_sub="student-sub-1")
+
+    assert exam_id == "exam-1"
 
 
 def test_save_notation_payload_persists_payload_under_student_key() -> None:

--- a/services/exam-api/tests/test_dynamodb_invite_repository.py
+++ b/services/exam-api/tests/test_dynamodb_invite_repository.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
+import pytest
 from botocore.exceptions import ClientError
 from grading_shared.domain.exam import Exam, ExamStatus
 from grading_shared.domain.models import MetaModel, NotationPayload, StudentModel, TotauxModel
-import pytest
 
 from exam_api.domain.errors import StudentExamScopeConflictError
 from exam_api.domain.student import Student
@@ -42,7 +42,8 @@ def test_get_exam_returns_exam_when_metadata_exists() -> None:
     )
 
 
-def test_upsert_student_scope_writes_student_item() -> None:
+@pytest.mark.asyncio
+async def test_upsert_student_scope_writes_student_item() -> None:
     table = Mock()
     dynamodb = Mock()
     dynamodb.Table.return_value = table
@@ -52,7 +53,7 @@ def test_upsert_student_scope_writes_student_item() -> None:
         dynamodb_resource=dynamodb,
     )
 
-    repository.upsert_student_scope(
+    await repository.upsert_student_scope(
         student=Student(
             student_id="student-sub-1",
             exam_id="exam-1",
@@ -86,7 +87,8 @@ def test_upsert_student_scope_writes_student_item() -> None:
     )
 
 
-def test_upsert_student_scope_raises_conflict_when_condition_fails() -> None:
+@pytest.mark.asyncio
+async def test_upsert_student_scope_raises_conflict_when_condition_fails() -> None:
     table = Mock()
     dynamodb = Mock()
     dynamodb.Table.return_value = table
@@ -110,7 +112,7 @@ def test_upsert_student_scope_raises_conflict_when_condition_fails() -> None:
     )
 
     with pytest.raises(StudentExamScopeConflictError):
-        repository.upsert_student_scope(
+        await repository.upsert_student_scope(
             student=Student(
                 student_id="student-sub-1",
                 exam_id="exam-2",
@@ -121,7 +123,8 @@ def test_upsert_student_scope_raises_conflict_when_condition_fails() -> None:
         )
 
 
-def test_get_student_scope_returns_student_record() -> None:
+@pytest.mark.asyncio
+async def test_get_student_scope_returns_student_record() -> None:
     table = Mock()
     table.get_item.return_value = {
         "Item": {
@@ -137,33 +140,12 @@ def test_get_student_scope_returns_student_record() -> None:
         dynamodb_resource=dynamodb,
     )
 
-    student = repository.get_student_scope(exam_id="exam-1", student_sub="student-sub-1")
+    student = await repository.get_student_scope(exam_id="exam-1", student_sub="student-sub-1")
 
     assert student is not None
     assert student.student_id == "student-sub-1"
     assert student.exam_id == "exam-1"
     assert str(student.email) == "student@example.com"
-
-
-def test_get_exam_id_for_student_sub_returns_exam_id() -> None:
-    table = Mock()
-    table.get_item.return_value = {
-        "Item": {
-            "PK": "STUDENT#student-sub-1",
-            "SK": "SCOPE",
-            "exam_id": "exam-1",
-        }
-    }
-    dynamodb = Mock()
-    dynamodb.Table.return_value = table
-    repository = DynamoDbInviteRepository(
-        table_name="grading-table",
-        dynamodb_resource=dynamodb,
-    )
-
-    exam_id = repository.get_exam_id_for_student_sub(student_sub="student-sub-1")
-
-    assert exam_id == "exam-1"
 
 
 def test_save_notation_payload_persists_payload_under_student_key() -> None:

--- a/services/exam-api/tests/test_dynamodb_invite_repository.py
+++ b/services/exam-api/tests/test_dynamodb_invite_repository.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
+from botocore.exceptions import ClientError
 from grading_shared.domain.exam import Exam, ExamStatus
 from grading_shared.domain.models import MetaModel, NotationPayload, StudentModel, TotauxModel
+import pytest
 
+from exam_api.domain.errors import StudentExamScopeConflictError
 from exam_api.domain.student import Student
 from exam_api.infrastructure.dynamodb_invite_repository import DynamoDbInviteRepository
 
@@ -43,6 +46,7 @@ def test_upsert_student_scope_writes_student_item() -> None:
     table = Mock()
     dynamodb = Mock()
     dynamodb.Table.return_value = table
+    dynamodb.meta.client = Mock()
     repository = DynamoDbInviteRepository(
         table_name="grading-table",
         dynamodb_resource=dynamodb,
@@ -58,20 +62,63 @@ def test_upsert_student_scope_writes_student_item() -> None:
         external_student_id="roster-17",
     )
 
-    first_call_kwargs = table.update_item.call_args_list[0].kwargs
-    second_call_kwargs = table.update_item.call_args_list[1].kwargs
-    assert table.update_item.call_count == 2
-    assert second_call_kwargs["Key"]["PK"] == "STUDENT#student-sub-1"
-    assert second_call_kwargs["Key"]["SK"] == "SCOPE"
-    assert second_call_kwargs["ExpressionAttributeValues"][":exam_id"] == "exam-1"
+    transact_kwargs = dynamodb.meta.client.transact_write_items.call_args.kwargs
+    assert len(transact_kwargs["TransactItems"]) == 2
+    exam_scope_write = transact_kwargs["TransactItems"][0]["Update"]
+    reverse_scope_write = transact_kwargs["TransactItems"][1]["Update"]
 
-    call_kwargs = first_call_kwargs
-    assert call_kwargs["Key"]["PK"] == "EXAM#exam-1"
-    assert call_kwargs["Key"]["SK"] == "STUDENT#student-sub-1"
-    assert "if_not_exists(invited_at, :invited_at)" in call_kwargs["UpdateExpression"]
-    assert call_kwargs["ExpressionAttributeValues"][":teacher_id"] == "teacher-1"
-    assert call_kwargs["ExpressionAttributeValues"][":external_student_id"] == "roster-17"
-    assert call_kwargs["ExpressionAttributeValues"][":email"] == "student@example.com"
+    assert exam_scope_write["Key"]["PK"]["S"] == "EXAM#exam-1"
+    assert exam_scope_write["Key"]["SK"]["S"] == "STUDENT#student-sub-1"
+    assert "if_not_exists(invited_at, :invited_at)" in exam_scope_write["UpdateExpression"]
+    assert exam_scope_write["ExpressionAttributeValues"][":teacher_id"]["S"] == "teacher-1"
+    assert (
+        exam_scope_write["ExpressionAttributeValues"][":external_student_id"]["S"]
+        == "roster-17"
+    )
+    assert exam_scope_write["ExpressionAttributeValues"][":email"]["S"] == "student@example.com"
+
+    assert reverse_scope_write["Key"]["PK"]["S"] == "STUDENT#student-sub-1"
+    assert reverse_scope_write["Key"]["SK"]["S"] == "SCOPE"
+    assert reverse_scope_write["ExpressionAttributeValues"][":exam_id"]["S"] == "exam-1"
+    assert (
+        reverse_scope_write["ConditionExpression"]
+        == "attribute_not_exists(exam_id) OR exam_id = :exam_id"
+    )
+
+
+def test_upsert_student_scope_raises_conflict_when_condition_fails() -> None:
+    table = Mock()
+    dynamodb = Mock()
+    dynamodb.Table.return_value = table
+    dynamodb.meta.client = Mock()
+    dynamodb.meta.client.transact_write_items.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "TransactionCanceledException",
+                "Message": "Transaction cancelled",
+            },
+            "CancellationReasons": [
+                {"Code": "None"},
+                {"Code": "ConditionalCheckFailed"},
+            ],
+        },
+        operation_name="TransactWriteItems",
+    )
+    repository = DynamoDbInviteRepository(
+        table_name="grading-table",
+        dynamodb_resource=dynamodb,
+    )
+
+    with pytest.raises(StudentExamScopeConflictError):
+        repository.upsert_student_scope(
+            student=Student(
+                student_id="student-sub-1",
+                exam_id="exam-2",
+                email="student@example.com",
+            ),
+            teacher_id="teacher-1",
+            external_student_id="roster-17",
+        )
 
 
 def test_get_student_scope_returns_student_record() -> None:

--- a/services/exam-api/tests/test_invite_student.py
+++ b/services/exam-api/tests/test_invite_student.py
@@ -43,7 +43,7 @@ def _make_client_error(code: str, message: str) -> ClientError:
 def client() -> TestClient:
     app = FastAPI()
     app.include_router(router)
-    app.state.student_invite_service = Mock(spec=["invite_student"])
+    app.state.student_invite_service = Mock(spec=["lookup_student_sub_by_email", "invite_student"])
     invite_repository = Mock()
     invite_repository.get_exam = Mock()
     invite_repository.save_exam = Mock()
@@ -66,12 +66,16 @@ def _build_use_case(
     exam_repository: Mock | None = None,
     student_scope_repository: Mock | None = None,
 ) -> InviteStudentUseCase:
+    invite_adapter = invite_service
+    if invite_adapter is None:
+        invite_adapter = Mock()
+        invite_adapter.lookup_student_sub_by_email.return_value = None
     scope_repository = student_scope_repository
     if scope_repository is None:
         scope_repository = Mock()
         scope_repository.get_exam_id_for_student_sub.return_value = None
     return InviteStudentUseCase(
-        invite_service=invite_service or Mock(),
+        invite_service=invite_adapter,
         exam_repository=exam_repository or Mock(),
         student_scope_repository=scope_repository,
     )
@@ -79,6 +83,7 @@ def _build_use_case(
 
 def test_use_case_returns_new_invite_result() -> None:
     invite_service = Mock()
+    invite_service.lookup_student_sub_by_email.return_value = None
     exam_repository = Mock()
     exam_repository.get_exam.return_value = Exam(
         exam_id="exam-1",
@@ -119,15 +124,19 @@ def test_use_case_returns_new_invite_result() -> None:
         student_email="student@example.com",
         exam_id="exam-1",
     )
-    student_scope_repository.get_exam_id_for_student_sub.assert_called_once_with(
-        student_sub="student-sub-123"
+    invite_service.lookup_student_sub_by_email.assert_called_once_with(
+        student_email="student@example.com"
     )
+    student_scope_repository.get_exam_id_for_student_sub.assert_not_called()
     student_scope_repository.upsert_student_scope.assert_called_once()
 
 
 def test_use_case_returns_reinvited_true_when_student_exists() -> None:
     invite_service = Mock()
+    invite_service.lookup_student_sub_by_email.return_value = "student-sub-existing"
     exam_repository = Mock()
+    student_scope_repository = Mock()
+    student_scope_repository.get_exam_id_for_student_sub.return_value = "exam-1"
     exam_repository.get_exam.return_value = Exam(
         exam_id="exam-1",
         teacher_id="teacher-1",
@@ -138,7 +147,11 @@ def test_use_case_returns_reinvited_true_when_student_exists() -> None:
         cognito_sub="student-sub-existing",
         already_existed=True,
     )
-    use_case = _build_use_case(invite_service=invite_service, exam_repository=exam_repository)
+    use_case = _build_use_case(
+        invite_service=invite_service,
+        exam_repository=exam_repository,
+        student_scope_repository=student_scope_repository,
+    )
 
     result = use_case.execute(
         InviteStudentCommand(
@@ -151,10 +164,15 @@ def test_use_case_returns_reinvited_true_when_student_exists() -> None:
 
     assert result.re_invited is True
     assert result.student.student_id == "student-sub-existing"
+    student_scope_repository.get_exam_id_for_student_sub.assert_called_once_with(
+        student_sub="student-sub-existing"
+    )
+    student_scope_repository.upsert_student_scope.assert_called_once()
 
 
 def test_use_case_raises_scope_conflict_when_student_belongs_to_other_exam() -> None:
     invite_service = Mock()
+    invite_service.lookup_student_sub_by_email.return_value = "student-sub-existing"
     exam_repository = Mock()
     student_scope_repository = Mock()
     exam_repository.get_exam.return_value = Exam(
@@ -162,10 +180,6 @@ def test_use_case_raises_scope_conflict_when_student_belongs_to_other_exam() -> 
         teacher_id="teacher-1",
         title="Math Midterm",
         status=ExamStatus.DRAFT,
-    )
-    invite_service.invite_student.return_value = PortInviteStudentResult(
-        cognito_sub="student-sub-existing",
-        already_existed=True,
     )
     student_scope_repository.get_exam_id_for_student_sub.return_value = "exam-legacy"
     use_case = _build_use_case(
@@ -184,6 +198,7 @@ def test_use_case_raises_scope_conflict_when_student_belongs_to_other_exam() -> 
             )
         )
 
+    invite_service.invite_student.assert_not_called()
     student_scope_repository.upsert_student_scope.assert_not_called()
 
 
@@ -284,6 +299,41 @@ def test_adapter_handles_existing_user_without_duplicate_account() -> None:
     cognito.admin_set_user_password.assert_called_once()
     cognito.admin_add_user_to_group.assert_called_once()
     ses.send_email.assert_called_once()
+
+
+def test_adapter_lookup_student_sub_by_email_returns_sub_when_exists() -> None:
+    cognito = Mock()
+    cognito.admin_get_user.return_value = {
+        "UserAttributes": [{"Name": "sub", "Value": "existing-sub"}]
+    }
+    adapter = CognitoSesStudentInviteAdapter(
+        user_pool_id="pool-id",
+        ses_from_address="noreply@example.com",
+        cognito_client=cognito,
+        ses_client=Mock(),
+    )
+
+    student_sub = adapter.lookup_student_sub_by_email(student_email="student@example.com")
+
+    assert student_sub == "existing-sub"
+
+
+def test_adapter_lookup_student_sub_by_email_returns_none_when_user_not_found() -> None:
+    cognito = Mock()
+    cognito.admin_get_user.side_effect = _make_client_error(
+        "UserNotFoundException",
+        "Not found",
+    )
+    adapter = CognitoSesStudentInviteAdapter(
+        user_pool_id="pool-id",
+        ses_from_address="noreply@example.com",
+        cognito_client=cognito,
+        ses_client=Mock(),
+    )
+
+    student_sub = adapter.lookup_student_sub_by_email(student_email="student@example.com")
+
+    assert student_sub is None
 
 
 def test_api_returns_200_on_successful_invite(client: TestClient) -> None:

--- a/services/exam-api/tests/test_invite_student.py
+++ b/services/exam-api/tests/test_invite_student.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from botocore.exceptions import ClientError
@@ -43,14 +43,13 @@ def _make_client_error(code: str, message: str) -> ClientError:
 def client() -> TestClient:
     app = FastAPI()
     app.include_router(router)
-    app.state.student_invite_service = Mock(spec=["lookup_student_sub_by_email", "invite_student"])
+    app.state.student_invite_service = Mock(spec=["invite_student"])
     invite_repository = Mock()
     invite_repository.get_exam = Mock()
     invite_repository.save_exam = Mock()
     invite_repository.save_notation_payload = Mock()
-    invite_repository.upsert_student_scope = Mock()
-    invite_repository.get_student_scope = Mock()
-    invite_repository.get_exam_id_for_student_sub = Mock()
+    invite_repository.upsert_student_scope = AsyncMock()
+    invite_repository.get_student_scope = AsyncMock()
     app.state.invite_repository = invite_repository
     app.state.jwt_verifier = Mock(spec=["decode_and_verify_token"])
     test_client = TestClient(app)
@@ -69,11 +68,11 @@ def _build_use_case(
     invite_adapter = invite_service
     if invite_adapter is None:
         invite_adapter = Mock()
-        invite_adapter.lookup_student_sub_by_email.return_value = None
+        invite_adapter.invite_student = AsyncMock()
     scope_repository = student_scope_repository
     if scope_repository is None:
         scope_repository = Mock()
-        scope_repository.get_exam_id_for_student_sub.return_value = None
+        scope_repository.upsert_student_scope = AsyncMock()
     return InviteStudentUseCase(
         invite_service=invite_adapter,
         exam_repository=exam_repository or Mock(),
@@ -81,9 +80,15 @@ def _build_use_case(
     )
 
 
-def test_use_case_returns_new_invite_result() -> None:
+@pytest.mark.asyncio
+async def test_use_case_returns_new_invite_result() -> None:
     invite_service = Mock()
-    invite_service.lookup_student_sub_by_email.return_value = None
+    invite_service.invite_student = AsyncMock(
+        return_value=PortInviteStudentResult(
+            cognito_sub="student-sub-123",
+            already_existed=False,
+        )
+    )
     exam_repository = Mock()
     exam_repository.get_exam.return_value = Exam(
         exam_id="exam-1",
@@ -92,18 +97,14 @@ def test_use_case_returns_new_invite_result() -> None:
         status=ExamStatus.DRAFT,
     )
     student_scope_repository = Mock()
-    student_scope_repository.get_exam_id_for_student_sub.return_value = None
-    invite_service.invite_student.return_value = PortInviteStudentResult(
-        cognito_sub="student-sub-123",
-        already_existed=False,
-    )
+    student_scope_repository.upsert_student_scope = AsyncMock()
     use_case = _build_use_case(
         invite_service=invite_service,
         exam_repository=exam_repository,
         student_scope_repository=student_scope_repository,
     )
 
-    result = use_case.execute(
+    result = await use_case.execute(
         InviteStudentCommand(
             exam_id="exam-1",
             student_id="student-external-id",
@@ -120,32 +121,30 @@ def test_use_case_returns_new_invite_result() -> None:
         ),
         re_invited=False,
     )
-    invite_service.invite_student.assert_called_once_with(
+    invite_service.invite_student.assert_awaited_once_with(
         student_email="student@example.com",
         exam_id="exam-1",
     )
-    invite_service.lookup_student_sub_by_email.assert_called_once_with(
-        student_email="student@example.com"
-    )
-    student_scope_repository.get_exam_id_for_student_sub.assert_not_called()
-    student_scope_repository.upsert_student_scope.assert_called_once()
+    student_scope_repository.upsert_student_scope.assert_awaited_once()
 
 
-def test_use_case_returns_reinvited_true_when_student_exists() -> None:
+@pytest.mark.asyncio
+async def test_use_case_returns_reinvited_true_when_student_exists() -> None:
     invite_service = Mock()
-    invite_service.lookup_student_sub_by_email.return_value = "student-sub-existing"
+    invite_service.invite_student = AsyncMock(
+        return_value=PortInviteStudentResult(
+            cognito_sub="student-sub-existing",
+            already_existed=True,
+        )
+    )
     exam_repository = Mock()
     student_scope_repository = Mock()
-    student_scope_repository.get_exam_id_for_student_sub.return_value = "exam-1"
+    student_scope_repository.upsert_student_scope = AsyncMock()
     exam_repository.get_exam.return_value = Exam(
         exam_id="exam-1",
         teacher_id="teacher-1",
         title="Math Midterm",
         status=ExamStatus.DRAFT,
-    )
-    invite_service.invite_student.return_value = PortInviteStudentResult(
-        cognito_sub="student-sub-existing",
-        already_existed=True,
     )
     use_case = _build_use_case(
         invite_service=invite_service,
@@ -153,7 +152,7 @@ def test_use_case_returns_reinvited_true_when_student_exists() -> None:
         student_scope_repository=student_scope_repository,
     )
 
-    result = use_case.execute(
+    result = await use_case.execute(
         InviteStudentCommand(
             exam_id="exam-1",
             student_id="student-external-id",
@@ -164,15 +163,18 @@ def test_use_case_returns_reinvited_true_when_student_exists() -> None:
 
     assert result.re_invited is True
     assert result.student.student_id == "student-sub-existing"
-    student_scope_repository.get_exam_id_for_student_sub.assert_called_once_with(
-        student_sub="student-sub-existing"
-    )
-    student_scope_repository.upsert_student_scope.assert_called_once()
+    student_scope_repository.upsert_student_scope.assert_awaited_once()
 
 
-def test_use_case_raises_scope_conflict_when_student_belongs_to_other_exam() -> None:
+@pytest.mark.asyncio
+async def test_use_case_raises_scope_conflict_from_dynamo_upsert() -> None:
     invite_service = Mock()
-    invite_service.lookup_student_sub_by_email.return_value = "student-sub-existing"
+    invite_service.invite_student = AsyncMock(
+        return_value=PortInviteStudentResult(
+            cognito_sub="student-sub-existing",
+            already_existed=True,
+        )
+    )
     exam_repository = Mock()
     student_scope_repository = Mock()
     exam_repository.get_exam.return_value = Exam(
@@ -181,7 +183,11 @@ def test_use_case_raises_scope_conflict_when_student_belongs_to_other_exam() -> 
         title="Math Midterm",
         status=ExamStatus.DRAFT,
     )
-    student_scope_repository.get_exam_id_for_student_sub.return_value = "exam-legacy"
+    student_scope_repository.upsert_student_scope = AsyncMock(
+        side_effect=StudentExamScopeConflictError(
+            "Student account is already scoped to another exam."
+        )
+    )
     use_case = _build_use_case(
         invite_service=invite_service,
         exam_repository=exam_repository,
@@ -189,7 +195,7 @@ def test_use_case_raises_scope_conflict_when_student_belongs_to_other_exam() -> 
     )
 
     with pytest.raises(StudentExamScopeConflictError):
-        use_case.execute(
+        await use_case.execute(
             InviteStudentCommand(
                 exam_id="exam-1",
                 student_id="student-external-id",
@@ -198,17 +204,18 @@ def test_use_case_raises_scope_conflict_when_student_belongs_to_other_exam() -> 
             )
         )
 
-    invite_service.invite_student.assert_not_called()
-    student_scope_repository.upsert_student_scope.assert_not_called()
+    invite_service.invite_student.assert_awaited_once()
+    student_scope_repository.upsert_student_scope.assert_awaited_once()
 
 
-def test_use_case_raises_exam_not_found() -> None:
+@pytest.mark.asyncio
+async def test_use_case_raises_exam_not_found() -> None:
     exam_repository = Mock()
     exam_repository.get_exam.return_value = None
     use_case = _build_use_case(exam_repository=exam_repository)
 
     with pytest.raises(ExamNotFoundError):
-        use_case.execute(
+        await use_case.execute(
             InviteStudentCommand(
                 exam_id="exam-missing",
                 student_id="student-external-id",
@@ -218,7 +225,8 @@ def test_use_case_raises_exam_not_found() -> None:
         )
 
 
-def test_use_case_raises_exam_ownership_error() -> None:
+@pytest.mark.asyncio
+async def test_use_case_raises_exam_ownership_error() -> None:
     exam_repository = Mock()
     exam_repository.get_exam.return_value = Exam(
         exam_id="exam-1",
@@ -229,7 +237,7 @@ def test_use_case_raises_exam_ownership_error() -> None:
     use_case = _build_use_case(exam_repository=exam_repository)
 
     with pytest.raises(ExamOwnershipError):
-        use_case.execute(
+        await use_case.execute(
             InviteStudentCommand(
                 exam_id="exam-1",
                 student_id="student-external-id",
@@ -239,7 +247,8 @@ def test_use_case_raises_exam_ownership_error() -> None:
         )
 
 
-def test_adapter_creates_cognito_user_and_sends_email() -> None:
+@pytest.mark.asyncio
+async def test_adapter_creates_cognito_user_and_sends_email() -> None:
     cognito = Mock()
     ses = Mock()
     cognito.admin_create_user.return_value = {
@@ -257,7 +266,7 @@ def test_adapter_creates_cognito_user_and_sends_email() -> None:
         ses_client=ses,
     )
 
-    result = adapter.invite_student(student_email="student@example.com", exam_id="exam-1")
+    result = await adapter.invite_student(student_email="student@example.com", exam_id="exam-1")
 
     assert result.cognito_sub == "student-sub-123"
     assert result.already_existed is False
@@ -273,7 +282,8 @@ def test_adapter_creates_cognito_user_and_sends_email() -> None:
     ses.send_email.assert_called_once()
 
 
-def test_adapter_handles_existing_user_without_duplicate_account() -> None:
+@pytest.mark.asyncio
+async def test_adapter_handles_existing_user_without_duplicate_account() -> None:
     cognito = Mock()
     ses = Mock()
     cognito.admin_create_user.side_effect = _make_client_error(
@@ -292,59 +302,27 @@ def test_adapter_handles_existing_user_without_duplicate_account() -> None:
         ses_client=ses,
     )
 
-    result = adapter.invite_student(student_email="student@example.com", exam_id="exam-1")
+    result = await adapter.invite_student(student_email="student@example.com", exam_id="exam-1")
 
     assert result.cognito_sub == "existing-sub"
     assert result.already_existed is True
+    cognito.admin_get_user.assert_called_once()
     cognito.admin_set_user_password.assert_called_once()
     cognito.admin_add_user_to_group.assert_called_once()
     ses.send_email.assert_called_once()
 
 
-def test_adapter_lookup_student_sub_by_email_returns_sub_when_exists() -> None:
-    cognito = Mock()
-    cognito.admin_get_user.return_value = {
-        "UserAttributes": [{"Name": "sub", "Value": "existing-sub"}]
-    }
-    adapter = CognitoSesStudentInviteAdapter(
-        user_pool_id="pool-id",
-        ses_from_address="noreply@example.com",
-        cognito_client=cognito,
-        ses_client=Mock(),
-    )
-
-    student_sub = adapter.lookup_student_sub_by_email(student_email="student@example.com")
-
-    assert student_sub == "existing-sub"
-
-
-def test_adapter_lookup_student_sub_by_email_returns_none_when_user_not_found() -> None:
-    cognito = Mock()
-    cognito.admin_get_user.side_effect = _make_client_error(
-        "UserNotFoundException",
-        "Not found",
-    )
-    adapter = CognitoSesStudentInviteAdapter(
-        user_pool_id="pool-id",
-        ses_from_address="noreply@example.com",
-        cognito_client=cognito,
-        ses_client=Mock(),
-    )
-
-    student_sub = adapter.lookup_student_sub_by_email(student_email="student@example.com")
-
-    assert student_sub is None
-
-
 def test_api_returns_200_on_successful_invite(client: TestClient) -> None:
     mock_use_case = Mock()
-    mock_use_case.execute.return_value = InviteStudentResult(
-        student=Student(
-            student_id="student-sub-123",
-            exam_id="exam-1",
-            email="student@example.com",
-        ),
-        re_invited=False,
+    mock_use_case.execute = AsyncMock(
+        return_value=InviteStudentResult(
+            student=Student(
+                student_id="student-sub-123",
+                exam_id="exam-1",
+                email="student@example.com",
+            ),
+            re_invited=False,
+        )
     )
     client.app.dependency_overrides[provide_invite_use_case] = lambda: mock_use_case
     client.app.dependency_overrides[get_current_teacher] = lambda: CurrentTeacher(
@@ -368,13 +346,15 @@ def test_api_returns_200_on_successful_invite(client: TestClient) -> None:
 
 def test_api_returns_reinvited_true_on_reinvite(client: TestClient) -> None:
     mock_use_case = Mock()
-    mock_use_case.execute.return_value = InviteStudentResult(
-        student=Student(
-            student_id="student-sub-existing",
-            exam_id="exam-1",
-            email="student@example.com",
-        ),
-        re_invited=True,
+    mock_use_case.execute = AsyncMock(
+        return_value=InviteStudentResult(
+            student=Student(
+                student_id="student-sub-existing",
+                exam_id="exam-1",
+                email="student@example.com",
+            ),
+            re_invited=True,
+        )
     )
     client.app.dependency_overrides[provide_invite_use_case] = lambda: mock_use_case
     client.app.dependency_overrides[get_current_teacher] = lambda: CurrentTeacher(
@@ -392,7 +372,7 @@ def test_api_returns_reinvited_true_on_reinvite(client: TestClient) -> None:
 
 def test_api_returns_404_when_exam_not_found(client: TestClient) -> None:
     mock_use_case = Mock()
-    mock_use_case.execute.side_effect = ExamNotFoundError("exam not found")
+    mock_use_case.execute = AsyncMock(side_effect=ExamNotFoundError("exam not found"))
     client.app.dependency_overrides[provide_invite_use_case] = lambda: mock_use_case
     client.app.dependency_overrides[get_current_teacher] = lambda: CurrentTeacher(
         teacher_id="teacher-1"
@@ -409,7 +389,7 @@ def test_api_returns_404_when_exam_not_found(client: TestClient) -> None:
 
 def test_api_returns_403_when_teacher_does_not_own_exam(client: TestClient) -> None:
     mock_use_case = Mock()
-    mock_use_case.execute.side_effect = ExamOwnershipError("forbidden")
+    mock_use_case.execute = AsyncMock(side_effect=ExamOwnershipError("forbidden"))
     client.app.dependency_overrides[provide_invite_use_case] = lambda: mock_use_case
     client.app.dependency_overrides[get_current_teacher] = lambda: CurrentTeacher(
         teacher_id="teacher-1"
@@ -426,7 +406,7 @@ def test_api_returns_403_when_teacher_does_not_own_exam(client: TestClient) -> N
 
 def test_api_returns_409_on_student_exam_scope_conflict(client: TestClient) -> None:
     mock_use_case = Mock()
-    mock_use_case.execute.side_effect = StudentExamScopeConflictError("scope conflict")
+    mock_use_case.execute = AsyncMock(side_effect=StudentExamScopeConflictError("scope conflict"))
     client.app.dependency_overrides[provide_invite_use_case] = lambda: mock_use_case
     client.app.dependency_overrides[get_current_teacher] = lambda: CurrentTeacher(
         teacher_id="teacher-1"
@@ -443,6 +423,7 @@ def test_api_returns_409_on_student_exam_scope_conflict(client: TestClient) -> N
 
 def test_api_returns_401_when_token_invalid(client: TestClient) -> None:
     mock_use_case = Mock()
+    mock_use_case.execute = AsyncMock()
     client.app.state.jwt_verifier.decode_and_verify_token.side_effect = JWTError(
         "invalid token"
     )
@@ -460,6 +441,7 @@ def test_api_returns_401_when_token_invalid(client: TestClient) -> None:
 
 def test_api_returns_403_for_non_teacher_claim(client: TestClient) -> None:
     mock_use_case = Mock()
+    mock_use_case.execute = AsyncMock()
     client.app.state.jwt_verifier.decode_and_verify_token.return_value = {
         "sub": "teacher-1",
         "custom:role": "student",
@@ -484,10 +466,12 @@ def test_student_scope_endpoint_returns_200_for_matching_student_scope(
         "custom:role": "student",
         "token_use": "id",
     }
-    client.app.state.invite_repository.get_student_scope.return_value = Student(
-        student_id="student-sub-123",
-        exam_id="exam-1",
-        email="student@example.com",
+    client.app.state.invite_repository.get_student_scope = AsyncMock(
+        return_value=Student(
+            student_id="student-sub-123",
+            exam_id="exam-1",
+            email="student@example.com",
+        )
     )
 
     response = client.get(
@@ -525,10 +509,12 @@ def test_student_scope_endpoint_ignores_custom_exam_id_claim(client: TestClient)
         "custom:exam_id": "exam-from-token",
         "token_use": "id",
     }
-    client.app.state.invite_repository.get_student_scope.return_value = Student(
-        student_id="student-sub-123",
-        exam_id="exam-from-path",
-        email="student@example.com",
+    client.app.state.invite_repository.get_student_scope = AsyncMock(
+        return_value=Student(
+            student_id="student-sub-123",
+            exam_id="exam-from-path",
+            email="student@example.com",
+        )
     )
 
     response = client.get(
@@ -548,7 +534,7 @@ def test_student_scope_endpoint_returns_404_when_scope_is_missing(
         "custom:role": "student",
         "token_use": "id",
     }
-    client.app.state.invite_repository.get_student_scope.return_value = None
+    client.app.state.invite_repository.get_student_scope = AsyncMock(return_value=None)
 
     response = client.get(
         "/exams/exam-1/students/student-sub-123/scope",

--- a/services/exam-api/tests/test_invite_student.py
+++ b/services/exam-api/tests/test_invite_student.py
@@ -50,6 +50,7 @@ def client() -> TestClient:
     invite_repository.save_notation_payload = Mock()
     invite_repository.upsert_student_scope = Mock()
     invite_repository.get_student_scope = Mock()
+    invite_repository.get_exam_id_for_student_sub = Mock()
     app.state.invite_repository = invite_repository
     app.state.jwt_verifier = Mock(spec=["decode_and_verify_token"])
     test_client = TestClient(app)
@@ -65,10 +66,14 @@ def _build_use_case(
     exam_repository: Mock | None = None,
     student_scope_repository: Mock | None = None,
 ) -> InviteStudentUseCase:
+    scope_repository = student_scope_repository
+    if scope_repository is None:
+        scope_repository = Mock()
+        scope_repository.get_exam_id_for_student_sub.return_value = None
     return InviteStudentUseCase(
         invite_service=invite_service or Mock(),
         exam_repository=exam_repository or Mock(),
-        student_scope_repository=student_scope_repository or Mock(),
+        student_scope_repository=scope_repository,
     )
 
 
@@ -82,6 +87,7 @@ def test_use_case_returns_new_invite_result() -> None:
         status=ExamStatus.DRAFT,
     )
     student_scope_repository = Mock()
+    student_scope_repository.get_exam_id_for_student_sub.return_value = None
     invite_service.invite_student.return_value = PortInviteStudentResult(
         cognito_sub="student-sub-123",
         already_existed=False,
@@ -113,6 +119,9 @@ def test_use_case_returns_new_invite_result() -> None:
         student_email="student@example.com",
         exam_id="exam-1",
     )
+    student_scope_repository.get_exam_id_for_student_sub.assert_called_once_with(
+        student_sub="student-sub-123"
+    )
     student_scope_repository.upsert_student_scope.assert_called_once()
 
 
@@ -142,6 +151,40 @@ def test_use_case_returns_reinvited_true_when_student_exists() -> None:
 
     assert result.re_invited is True
     assert result.student.student_id == "student-sub-existing"
+
+
+def test_use_case_raises_scope_conflict_when_student_belongs_to_other_exam() -> None:
+    invite_service = Mock()
+    exam_repository = Mock()
+    student_scope_repository = Mock()
+    exam_repository.get_exam.return_value = Exam(
+        exam_id="exam-1",
+        teacher_id="teacher-1",
+        title="Math Midterm",
+        status=ExamStatus.DRAFT,
+    )
+    invite_service.invite_student.return_value = PortInviteStudentResult(
+        cognito_sub="student-sub-existing",
+        already_existed=True,
+    )
+    student_scope_repository.get_exam_id_for_student_sub.return_value = "exam-legacy"
+    use_case = _build_use_case(
+        invite_service=invite_service,
+        exam_repository=exam_repository,
+        student_scope_repository=student_scope_repository,
+    )
+
+    with pytest.raises(StudentExamScopeConflictError):
+        use_case.execute(
+            InviteStudentCommand(
+                exam_id="exam-1",
+                student_id="student-external-id",
+                student_email="student@example.com",
+                teacher_id="teacher-1",
+            )
+        )
+
+    student_scope_repository.upsert_student_scope.assert_not_called()
 
 
 def test_use_case_raises_exam_not_found() -> None:
@@ -207,7 +250,6 @@ def test_adapter_creates_cognito_user_and_sends_email() -> None:
     create_call = cognito.admin_create_user.call_args.kwargs
     assert create_call["MessageAction"] == "SUPPRESS"
     assert {"Name": "custom:role", "Value": "student"} in create_call["UserAttributes"]
-    assert {"Name": "custom:exam_id", "Value": "exam-1"} in create_call["UserAttributes"]
     cognito.admin_add_user_to_group.assert_called_once_with(
         UserPoolId="pool-id",
         Username="student@example.com",
@@ -226,7 +268,6 @@ def test_adapter_handles_existing_user_without_duplicate_account() -> None:
     cognito.admin_get_user.return_value = {
         "UserAttributes": [
             {"Name": "sub", "Value": "existing-sub"},
-            {"Name": "custom:exam_id", "Value": "exam-1"},
         ]
     }
     adapter = CognitoSesStudentInviteAdapter(
@@ -243,33 +284,6 @@ def test_adapter_handles_existing_user_without_duplicate_account() -> None:
     cognito.admin_set_user_password.assert_called_once()
     cognito.admin_add_user_to_group.assert_called_once()
     ses.send_email.assert_called_once()
-
-
-def test_adapter_raises_conflict_when_existing_user_bound_to_other_exam() -> None:
-    cognito = Mock()
-    ses = Mock()
-    cognito.admin_create_user.side_effect = _make_client_error(
-        "UsernameExistsException",
-        "Already exists",
-    )
-    cognito.admin_get_user.return_value = {
-        "UserAttributes": [
-            {"Name": "sub", "Value": "existing-sub"},
-            {"Name": "custom:exam_id", "Value": "exam-legacy"},
-        ]
-    }
-    adapter = CognitoSesStudentInviteAdapter(
-        user_pool_id="pool-id",
-        ses_from_address="noreply@example.com",
-        cognito_client=cognito,
-        ses_client=ses,
-    )
-
-    with pytest.raises(StudentExamScopeConflictError):
-        adapter.invite_student(student_email="student@example.com", exam_id="exam-1")
-
-    cognito.admin_set_user_password.assert_not_called()
-    ses.send_email.assert_not_called()
 
 
 def test_api_returns_200_on_successful_invite(client: TestClient) -> None:
@@ -418,7 +432,6 @@ def test_student_scope_endpoint_returns_200_for_matching_student_scope(
     client.app.state.jwt_verifier.decode_and_verify_token.return_value = {
         "sub": "student-sub-123",
         "custom:role": "student",
-        "custom:exam_id": "exam-1",
         "token_use": "id",
     }
     client.app.state.invite_repository.get_student_scope.return_value = Student(
@@ -444,7 +457,6 @@ def test_student_scope_endpoint_returns_403_on_sub_mismatch(client: TestClient) 
     client.app.state.jwt_verifier.decode_and_verify_token.return_value = {
         "sub": "student-sub-abc",
         "custom:role": "student",
-        "custom:exam_id": "exam-1",
         "token_use": "id",
     }
 
@@ -456,20 +468,26 @@ def test_student_scope_endpoint_returns_403_on_sub_mismatch(client: TestClient) 
     assert response.status_code == 403
 
 
-def test_student_scope_endpoint_returns_403_on_exam_mismatch(client: TestClient) -> None:
+def test_student_scope_endpoint_ignores_custom_exam_id_claim(client: TestClient) -> None:
     client.app.state.jwt_verifier.decode_and_verify_token.return_value = {
         "sub": "student-sub-123",
         "custom:role": "student",
         "custom:exam_id": "exam-from-token",
         "token_use": "id",
     }
+    client.app.state.invite_repository.get_student_scope.return_value = Student(
+        student_id="student-sub-123",
+        exam_id="exam-from-path",
+        email="student@example.com",
+    )
 
     response = client.get(
         "/exams/exam-from-path/students/student-sub-123/scope",
         headers={"Authorization": "Bearer valid.token.value"},
     )
 
-    assert response.status_code == 403
+    assert response.status_code == 200
+    assert response.json()["exam_id"] == "exam-from-path"
 
 
 def test_student_scope_endpoint_returns_404_when_scope_is_missing(
@@ -478,7 +496,6 @@ def test_student_scope_endpoint_returns_404_when_scope_is_missing(
     client.app.state.jwt_verifier.decode_and_verify_token.return_value = {
         "sub": "student-sub-123",
         "custom:role": "student",
-        "custom:exam_id": "exam-1",
         "token_use": "id",
     }
     client.app.state.invite_repository.get_student_scope.return_value = None


### PR DESCRIPTION
DynamoDB is now the single source of truth for exam-student mapping and authorization scope (`PK=EXAM#{exam_id}`, `SK=STUDENT#{cognito_sub}`), with Cognito custom attributes no longer used to scope student access.

### Changes 1→5
- **1) API/Authz**: removed runtime dependency on `custom:exam_id` in student auth checks; student endpoints still validate JWT and `custom:role=student`, then authorize by DynamoDB mapping existence.
- **2) Application/Domain**: kept teacher ownership check, added explicit scope conflict handling in invite use case via DynamoDB lookup to prevent silent cross-exam scope mutation on re-invite.
- **3) Infrastructure adapters**: DynamoDB repository now persists and reads a reverse student scope key (`PK=STUDENT#{sub}`, `SK=SCOPE`) for conflict checks; Cognito invite adapter no longer writes/reads `custom:exam_id`, while preserving user create/reuse, students group assignment, and SES invitation email.
- **4) Tests**: updated/added unit and API tests for DynamoDB-based authorization, independence from `custom:exam_id`, 403/404/409 cases, and repository behavior.
- **5) Infra Auth (CDK)**: removed Cognito custom attribute `exam_id` from `infra/stacks/auth_stack.py`.

### Validation
- `uv run ruff check .` ✅
- `uv run pytest` ❌ (fails during collection because local `worktrees/pr58` duplicates test module paths)
- `uv run pytest --ignore=worktrees` ✅ (42 passed)

### Modified Files
- `services/exam-api/exam_api/api/invite_router.py`
- `services/exam-api/exam_api/application/invite_student.py`
- `services/exam-api/exam_api/infrastructure/dynamodb_invite_repository.py`
- `services/exam-api/exam_api/infrastructure/student_invite_adapter.py`
- `services/exam-api/exam_api/ports/student_scope_repository_port.py`
- `services/exam-api/exam_api/ports/student_invite_port.py`
- `services/exam-api/tests/test_invite_student.py`
- `services/exam-api/tests/test_dynamodb_invite_repository.py`
- `infra/stacks/auth_stack.py`
- `README.md`

### Residual Risks
- Existing legacy student mappings created before reverse scope key persistence (`PK=STUDENT#{sub}`, `SK=SCOPE`) may not trigger cross-exam conflict until re-invite writes the reverse record.

## Acceptance Criteria
- [ ] `POST /exams/{exam_id}/students/{student_id}/invite` envoie un email d’invitation via SES avec un mot de passe temporaire.
- [ ] Cognito admin crée l’utilisateur dans le groupe `students` avec `custom:role=student` (sans dépendre de `custom:exam_id` pour l’autorisation).
- [ ] Le scope étudiant est garanti par DynamoDB comme source de vérité unique: un étudiant ne peut lire que les données où un mapping `PK=EXAM#{exam_id}`, `SK=STUDENT#{cognito_sub}` existe.
- [ ] Re-inviter un étudiant déjà invité ré-envoie l’email sans dupliquer le compte Cognito et sans casser le mapping DynamoDB existant.
- [ ] L’enseignant doit posséder l’examen pour inviter des étudiants à cet examen.

Made with [Cursor](https://cursor.com)