### PR TITLE
feat: Cognito admin group and RBAC for teacher registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Two roles, enforced by Cognito groups and FastAPI dependencies:
 | **Teacher** | Create exams, upload config + spreadsheets, manage student roster, trigger pipeline, view all results for their exams, download all PDFs |
 | **Student** | Upload their own spreadsheet, view their own grade breakdown, download their own PDF |
 
-Students are scoped by DynamoDB mappings: student-facing endpoints require a JWT with `custom:role=student` and a matching `sub`, then validate that `PK=EXAM#{exam_id}` and `SK=STUDENT#{sub}` exists.
+Students are scoped by DynamoDB mappings: student-facing endpoints require a JWT whose `cognito:groups` includes `students` and a matching `sub`, then validate that `PK=EXAM#{exam_id}` and `SK=STUDENT#{sub}` exists.
 
 ---
 

--- a/infra/pyproject.toml
+++ b/infra/pyproject.toml
@@ -11,11 +11,8 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",
-    "exam-api",
+    "pytest-asyncio>=1.3.0",
 ]
-
-[tool.uv.sources]
-exam-api = { workspace = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/infra/pyproject.toml
+++ b/infra/pyproject.toml
@@ -11,7 +11,11 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",
+    "exam-api",
 ]
+
+[tool.uv.sources]
+exam-api = { workspace = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/infra/stacks/auth_stack.py
+++ b/infra/stacks/auth_stack.py
@@ -10,8 +10,7 @@ class AuthStack(Stack):
     def __init__(self, scope: Construct, construct_id: str, **kwargs: object) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        # custom:role is set by application code (e.g. AdminUpdateUserAttributes) at
-        # teacher/student invitation — not by Cognito triggers in this stack.
+        # RBAC uses Cognito pool groups (teachers / students / admin) on the ID token.
         user_pool = cognito.UserPool(
             self,
             "GradingUserPool",
@@ -21,13 +20,6 @@ class AuthStack(Stack):
             standard_attributes=cognito.StandardAttributes(
                 email=cognito.StandardAttribute(required=True, mutable=False),
             ),
-            custom_attributes={
-                "role": cognito.StringAttribute(
-                    min_len=7,
-                    max_len=7,
-                    mutable=True,
-                ),
-            },
             password_policy=cognito.PasswordPolicy(
                 min_length=8,
                 require_uppercase=True,

--- a/infra/stacks/auth_stack.py
+++ b/infra/stacks/auth_stack.py
@@ -5,6 +5,12 @@ from aws_cdk import aws_ssm as ssm
 
 from constructs import Construct
 
+from stacks.constants import (
+    COGNITO_ADMIN_GROUP,
+    COGNITO_STUDENT_GROUP,
+    COGNITO_TEACHER_GROUP,
+)
+
 
 class AuthStack(Stack):
     def __init__(self, scope: Construct, construct_id: str, **kwargs: object) -> None:
@@ -33,7 +39,7 @@ class AuthStack(Stack):
             self,
             "TeachersGroup",
             user_pool_id=user_pool.user_pool_id,
-            group_name="teachers",
+            group_name=COGNITO_TEACHER_GROUP,
             description="Teacher users for grading platform.",
         )
 
@@ -41,7 +47,7 @@ class AuthStack(Stack):
             self,
             "StudentsGroup",
             user_pool_id=user_pool.user_pool_id,
-            group_name="students",
+            group_name=COGNITO_STUDENT_GROUP,
             description="Student users for grading platform.",
         )
 
@@ -49,7 +55,7 @@ class AuthStack(Stack):
             self,
             "AdminGroup",
             user_pool_id=user_pool.user_pool_id,
-            group_name="admin",
+            group_name=COGNITO_ADMIN_GROUP,
             description="Administrators who may register new teachers via the API.",
         )
 

--- a/infra/stacks/auth_stack.py
+++ b/infra/stacks/auth_stack.py
@@ -53,6 +53,14 @@ class AuthStack(Stack):
             description="Student users for grading platform.",
         )
 
+        cognito.CfnUserPoolGroup(
+            self,
+            "AdminGroup",
+            user_pool_id=user_pool.user_pool_id,
+            group_name="admin",
+            description="Administrators who may register new teachers via the API.",
+        )
+
         user_pool_client = user_pool.add_client(
             "GradingSpaClient",
             user_pool_client_name="grading-spa-client",

--- a/infra/stacks/constants.py
+++ b/infra/stacks/constants.py
@@ -1,0 +1,9 @@
+"""Cognito user pool group names.
+
+Must match ``exam_api.cognito_group_names`` (exam-api) — duplicated here so infra
+tests and CDK stacks do not depend on application code.
+"""
+
+COGNITO_TEACHER_GROUP = "teachers"
+COGNITO_STUDENT_GROUP = "students"
+COGNITO_ADMIN_GROUP = "admin"

--- a/infra/tests/test_auth_stack.py
+++ b/infra/tests/test_auth_stack.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 import aws_cdk as cdk
 import pytest
 from aws_cdk import assertions
-from exam_api.cognito_group_names import (
+from stacks.auth_stack import AuthStack
+from stacks.constants import (
     COGNITO_ADMIN_GROUP,
     COGNITO_STUDENT_GROUP,
     COGNITO_TEACHER_GROUP,
 )
-from stacks.auth_stack import AuthStack
 
 
 # ---------------------------------------------------------------------------

--- a/infra/tests/test_auth_stack.py
+++ b/infra/tests/test_auth_stack.py
@@ -103,6 +103,13 @@ def test_students_group_exists(template: assertions.Template) -> None:
     )
 
 
+def test_admin_group_exists(template: assertions.Template) -> None:
+    template.has_resource_properties(
+        "AWS::Cognito::UserPoolGroup",
+        {"GroupName": "admin"},
+    )
+
+
 # ---------------------------------------------------------------------------
 # App Client
 # ---------------------------------------------------------------------------

--- a/infra/tests/test_auth_stack.py
+++ b/infra/tests/test_auth_stack.py
@@ -9,6 +9,11 @@ from __future__ import annotations
 import aws_cdk as cdk
 import pytest
 from aws_cdk import assertions
+from exam_api.cognito_group_names import (
+    COGNITO_ADMIN_GROUP,
+    COGNITO_STUDENT_GROUP,
+    COGNITO_TEACHER_GROUP,
+)
 from stacks.auth_stack import AuthStack
 
 
@@ -60,30 +65,6 @@ def test_user_pool_password_policy(template: assertions.Template) -> None:
     )
 
 
-def test_user_pool_custom_role_attribute(template: assertions.Template) -> None:
-    template.has_resource_properties(
-        "AWS::Cognito::UserPool",
-        {
-            "Schema": assertions.Match.array_with(
-                [
-                    assertions.Match.object_like(
-                        {
-                            "Name": "role",
-                            "AttributeDataType": "String",
-                            "StringAttributeConstraints": assertions.Match.object_like(
-                                {
-                                    "MinLength": "7",
-                                    "MaxLength": "7",
-                                }
-                            ),
-                        }
-                    )
-                ]
-            )
-        },
-    )
-
-
 # ---------------------------------------------------------------------------
 # Groups
 # ---------------------------------------------------------------------------
@@ -92,21 +73,21 @@ def test_user_pool_custom_role_attribute(template: assertions.Template) -> None:
 def test_teachers_group_exists(template: assertions.Template) -> None:
     template.has_resource_properties(
         "AWS::Cognito::UserPoolGroup",
-        {"GroupName": "teachers"},
+        {"GroupName": COGNITO_TEACHER_GROUP},
     )
 
 
 def test_students_group_exists(template: assertions.Template) -> None:
     template.has_resource_properties(
         "AWS::Cognito::UserPoolGroup",
-        {"GroupName": "students"},
+        {"GroupName": COGNITO_STUDENT_GROUP},
     )
 
 
 def test_admin_group_exists(template: assertions.Template) -> None:
     template.has_resource_properties(
         "AWS::Cognito::UserPoolGroup",
-        {"GroupName": "admin"},
+        {"GroupName": COGNITO_ADMIN_GROUP},
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,16 @@ requires-python = ">=3.12"
 dependencies = []
 
 [tool.uv.workspace]
-members = ["shared", "services/*"]
+members = ["shared", "services/*", "infra"]
+
+[tool.uv.sources]
+exam-api = { workspace = true }
+grading-infra = { workspace = true }
 
 [dependency-groups]
 dev = [
+    "exam-api",
+    "grading-infra",
     "mypy>=1.20.2",
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
@@ -17,4 +23,6 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["services/exam-api/tests"]
+# Two `tests/` packages (exam-api + infra): avoid `tests.*` import clashes.
+addopts = "--import-mode=importlib"
+testpaths = ["services/exam-api/tests", "infra/tests"]

--- a/services/exam-api/docs/api.http
+++ b/services/exam-api/docs/api.http
@@ -8,9 +8,10 @@
 @baseUrl = http://localhost:8000
 
 # ---------------------------------------------------------------------------
-# After running "Login Teacher", copy the id_token here so all subsequent
-# requests that need @teacherToken work without re-running the login each time.
+# Register teacher: use an admin user's id_token (user must belong to Cognito group "Admin").
+# After running "Login Teacher", copy the id_token into @teacherToken for teacher APIs.
 # ---------------------------------------------------------------------------
+@adminToken  = PASTE_ADMIN_ID_TOKEN_HERE
 @teacherToken = PASTE_ID_TOKEN_FROM_LOGIN_RESPONSE
 @examId       = PASTE_EXAM_ID_HERE
 @studentId    = PASTE_STUDENT_ID_HERE
@@ -20,9 +21,10 @@
 # AUTH
 # ===========================================================================
 
-### Register Teacher — 201 Created
+### Register Teacher — 201 Created (requires Admin Cognito group)
 # @name registerTeacher
 POST {{baseUrl}}/auth/register
+Authorization: Bearer {{adminToken}}
 Content-Type: application/json
 
 {
@@ -35,6 +37,7 @@ Content-Type: application/json
 
 ### Register Teacher — 409 Conflict (duplicate email)
 POST {{baseUrl}}/auth/register
+Authorization: Bearer {{adminToken}}
 Content-Type: application/json
 
 {
@@ -47,6 +50,7 @@ Content-Type: application/json
 
 ### Register Teacher — 400 Bad Request (weak password)
 POST {{baseUrl}}/auth/register
+Authorization: Bearer {{adminToken}}
 Content-Type: application/json
 
 {

--- a/services/exam-api/docs/api.http
+++ b/services/exam-api/docs/api.http
@@ -8,7 +8,7 @@
 @baseUrl = http://localhost:8000
 
 # ---------------------------------------------------------------------------
-# Register teacher: use an admin user's id_token (user must belong to Cognito group "Admin").
+# Register teacher: use an admin user's id_token (user must belong to Cognito group "admin").
 # After running "Login Teacher", copy the id_token into @teacherToken for teacher APIs.
 # ---------------------------------------------------------------------------
 @adminToken  = PASTE_ADMIN_ID_TOKEN_HERE
@@ -21,7 +21,7 @@
 # AUTH
 # ===========================================================================
 
-### Register Teacher — 201 Created (requires Admin Cognito group)
+### Register Teacher — 201 Created (requires Cognito group "admin")
 # @name registerTeacher
 POST {{baseUrl}}/auth/register
 Authorization: Bearer {{adminToken}}

--- a/services/exam-api/exam_api/api/auth_router.py
+++ b/services/exam-api/exam_api/api/auth_router.py
@@ -23,6 +23,7 @@ from exam_api.api.dependencies import CurrentAdmin, require_admin
 from exam_api.domain.errors import (
     DuplicateEmailError,
     InvalidCredentialsError,
+    TeacherGroupAssignmentError,
     WeakPasswordError,
 )
 from exam_api.infrastructure.cognito_auth_adapter import CognitoAuthAdapter
@@ -106,6 +107,11 @@ async def register(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(err) or "Password does not meet the required policy.",
+        ) from err
+    except TeacherGroupAssignmentError as err:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(err) or "Teacher registration could not be completed.",
         ) from err
 
     return RegisterResponse(

--- a/services/exam-api/exam_api/api/auth_router.py
+++ b/services/exam-api/exam_api/api/auth_router.py
@@ -19,6 +19,7 @@ from exam_api.application.register_teacher import (
     RegisterTeacherCommand,
     RegisterTeacherUseCase,
 )
+from exam_api.api.dependencies import CurrentAdmin, require_admin
 from exam_api.domain.errors import (
     DuplicateEmailError,
     InvalidCredentialsError,
@@ -85,6 +86,7 @@ def get_login_use_case() -> LoginTeacherUseCase:
 )
 async def register(
     body: RegisterRequest,
+    _: Annotated[CurrentAdmin, Depends(require_admin)],
     use_case: Annotated[RegisterTeacherUseCase, Depends(get_register_use_case)],
 ) -> RegisterResponse:
     try:

--- a/services/exam-api/exam_api/api/dependencies.py
+++ b/services/exam-api/exam_api/api/dependencies.py
@@ -1,8 +1,8 @@
 """Centralised FastAPI dependency guards for role-based access control.
 
 Provides:
-    require_teacher  — rejects non-teacher JWTs with 403
-    require_student  — rejects non-student JWTs with 403
+    require_teacher  — rejects JWTs whose cognito:groups does not include teachers
+    require_student  — rejects JWTs whose cognito:groups does not include students
     require_admin    — rejects JWTs whose cognito:groups does not include admin
     require_own_data — rejects students accessing another student's resource with 403
 
@@ -28,7 +28,11 @@ from exam_api.domain.errors import (
     ExamOwnershipError,
 )
 from exam_api.ports.exam_ownership_port import ExamOwnershipPort
-from exam_api.cognito_group_names import COGNITO_ADMIN_GROUP
+from exam_api.cognito_group_names import (
+    COGNITO_ADMIN_GROUP,
+    COGNITO_STUDENT_GROUP,
+    COGNITO_TEACHER_GROUP,
+)
 from exam_api.ports.jwt_verifier_port import JwtVerifierPort
 
 # ---------------------------------------------------------------------------
@@ -118,19 +122,17 @@ async def require_teacher(
     request: Request,
     authorization: Annotated[str | None, Header()] = None,
 ) -> CurrentTeacher:
-    """Dependency: bearer token must carry custom:role=teacher.
+    """Dependency: ID token must include cognito:groups containing the teachers pool group."""
 
-    Raises 401 when the token is absent/invalid, 403 when the role is wrong.
-    """
     token = _bearer_token(authorization)
     jwt_verifier = _get_jwt_verifier(request)
     claims = await _decode_token(token, jwt_verifier)
-    role = claims.get("custom:role")
-    if role != "teacher":
+    groups = _cognito_groups_from_claims(claims)
+    if COGNITO_TEACHER_GROUP not in groups:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={
-                "error": "Teacher role required.",
+                "error": "Teacher group membership required.",
                 "code": "insufficient_role",
             },
         )
@@ -150,19 +152,17 @@ async def require_student(
     request: Request,
     authorization: Annotated[str | None, Header()] = None,
 ) -> CurrentStudent:
-    """Dependency: bearer token must carry custom:role=student.
+    """Dependency: ID token must include cognito:groups containing the students pool group."""
 
-    Raises 401 when the token is absent/invalid, 403 when the role is wrong.
-    """
     token = _bearer_token(authorization)
     jwt_verifier = _get_jwt_verifier(request)
     claims = await _decode_token(token, jwt_verifier)
-    role = claims.get("custom:role")
-    if role != "student":
+    groups = _cognito_groups_from_claims(claims)
+    if COGNITO_STUDENT_GROUP not in groups:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={
-                "error": "Student role required.",
+                "error": "Student group membership required.",
                 "code": "insufficient_role",
             },
         )

--- a/services/exam-api/exam_api/api/dependencies.py
+++ b/services/exam-api/exam_api/api/dependencies.py
@@ -182,7 +182,7 @@ async def require_admin(
     request: Request,
     authorization: Annotated[str | None, Header()] = None,
 ) -> CurrentAdmin:
-    """Dependency: ID token must include cognito:groups containing the Admin pool group."""
+    """Dependency: ID token must include cognito:groups containing the `admin` pool group."""
     token = _bearer_token(authorization)
     jwt_verifier = _get_jwt_verifier(request)
     claims = await _decode_token(token, jwt_verifier)
@@ -191,7 +191,7 @@ async def require_admin(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={
-                "error": "Admin group membership required.",
+                "error": "Administrator group membership required.",
                 "code": "insufficient_role",
             },
         )

--- a/services/exam-api/exam_api/api/dependencies.py
+++ b/services/exam-api/exam_api/api/dependencies.py
@@ -3,6 +3,7 @@
 Provides:
     require_teacher  — rejects non-teacher JWTs with 403
     require_student  — rejects non-student JWTs with 403
+    require_admin    — rejects JWTs whose cognito:groups does not include admin
     require_own_data — rejects students accessing another student's resource with 403
 
 All 401/403 responses use the canonical JSON body: {"error": "...", "code": "..."}.
@@ -10,7 +11,7 @@ All 401/403 responses use the canonical JSON body: {"error": "...", "code": "...
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import Depends, Header, HTTPException, Request, status
 from httpx import HTTPError
@@ -27,11 +28,18 @@ from exam_api.domain.errors import (
     ExamOwnershipError,
 )
 from exam_api.ports.exam_ownership_port import ExamOwnershipPort
+from exam_api.cognito_group_names import COGNITO_ADMIN_GROUP
 from exam_api.ports.jwt_verifier_port import JwtVerifierPort
 
 # ---------------------------------------------------------------------------
 # Shared value objects returned by the dependency guards
 # ---------------------------------------------------------------------------
+
+
+class CurrentAdmin(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    admin_id: str
 
 
 class CurrentTeacher(BaseModel):
@@ -79,7 +87,7 @@ def _bearer_token(authorization: str | None) -> str:
     return token
 
 
-async def _decode_token(token: str, jwt_verifier: JwtVerifierPort) -> dict:
+async def _decode_token(token: str, jwt_verifier: JwtVerifierPort) -> dict[str, Any]:
     try:
         return await jwt_verifier.decode_and_verify_token(token)
     except (HTTPError, JWTError) as err:
@@ -87,6 +95,18 @@ async def _decode_token(token: str, jwt_verifier: JwtVerifierPort) -> dict:
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail={"error": "Invalid or expired JWT token.", "code": "invalid_token"},
         ) from err
+
+
+def _cognito_groups_from_claims(claims: dict[str, Any]) -> list[str]:
+    """Normalise cognito:groups to a list of strings (Cognito uses a list; some mocks may differ)."""
+    raw = claims.get("cognito:groups")
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, list):
+        return [g for g in raw if isinstance(g, str)]
+    return []
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +176,35 @@ async def require_student(
             },
         )
     return CurrentStudent(student_id=student_id)
+
+
+async def require_admin(
+    request: Request,
+    authorization: Annotated[str | None, Header()] = None,
+) -> CurrentAdmin:
+    """Dependency: ID token must include cognito:groups containing the Admin pool group."""
+    token = _bearer_token(authorization)
+    jwt_verifier = _get_jwt_verifier(request)
+    claims = await _decode_token(token, jwt_verifier)
+    groups = _cognito_groups_from_claims(claims)
+    if COGNITO_ADMIN_GROUP not in groups:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "Admin group membership required.",
+                "code": "insufficient_role",
+            },
+        )
+    admin_id = claims.get("sub")
+    if not isinstance(admin_id, str) or not admin_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={
+                "error": "Missing administrator identifier in JWT claims.",
+                "code": "missing_subject",
+            },
+        )
+    return CurrentAdmin(admin_id=admin_id)
 
 
 def require_own_data(path_param_name: str):

--- a/services/exam-api/exam_api/cognito_group_names.py
+++ b/services/exam-api/exam_api/cognito_group_names.py
@@ -1,0 +1,6 @@
+"""Cognito user pool group names — must match infra/stacks/auth_stack.py CfnUserPoolGroup."""
+
+# AWS group names are case-sensitive. Teachers/students use lowercase pool groups; Admin is title case.
+COGNITO_TEACHER_GROUP = "teachers"
+COGNITO_STUDENT_GROUP = "students"
+COGNITO_ADMIN_GROUP = "admin"

--- a/services/exam-api/exam_api/cognito_group_names.py
+++ b/services/exam-api/exam_api/cognito_group_names.py
@@ -1,6 +1,6 @@
 """Cognito user pool group names — must match infra/stacks/auth_stack.py CfnUserPoolGroup."""
 
-# AWS group names are case-sensitive. Teachers/students use lowercase pool groups; Admin is title case.
+# All pool group names are lowercase (AWS Cognito group names are case-sensitive).
 COGNITO_TEACHER_GROUP = "teachers"
 COGNITO_STUDENT_GROUP = "students"
 COGNITO_ADMIN_GROUP = "admin"

--- a/services/exam-api/exam_api/domain/errors.py
+++ b/services/exam-api/exam_api/domain/errors.py
@@ -15,6 +15,10 @@ class WeakPasswordError(AuthError):
     """Raised when a teacher password does not match policy constraints."""
 
 
+class TeacherGroupAssignmentError(AuthError):
+    """Raised when Cognito user creation succeeded but teachers group assignment failed."""
+
+
 class InvalidCredentialsError(AuthError):
     """Raised when login credentials are invalid."""
 

--- a/services/exam-api/exam_api/infrastructure/cognito_auth_adapter.py
+++ b/services/exam-api/exam_api/infrastructure/cognito_auth_adapter.py
@@ -12,6 +12,7 @@ from botocore.exceptions import ClientError  # type: ignore[import-untyped]
 from exam_api.domain.errors import (
     DuplicateEmailError,
     InvalidCredentialsError,
+    TeacherGroupAssignmentError,
     WeakPasswordError,
 )
 from exam_api.cognito_group_names import COGNITO_TEACHER_GROUP
@@ -92,17 +93,24 @@ class CognitoAuthAdapter(AuthServicePort):
         except ClientError as err:
             error_code = self._extract_error_code(err)
             if error_code == "InvalidPasswordException":
+                await self._admin_delete_user_best_effort(client, email)
                 message = err.response.get("Error", {}).get(
                     "Message", "Password does not meet the required policy."
                 )
                 raise WeakPasswordError(message) from err
             raise
 
-        await client.admin_add_user_to_group(
-            UserPoolId=self._user_pool_id,
-            Username=email,
-            GroupName=COGNITO_TEACHER_GROUP,
-        )
+        try:
+            await client.admin_add_user_to_group(
+                UserPoolId=self._user_pool_id,
+                Username=email,
+                GroupName=COGNITO_TEACHER_GROUP,
+            )
+        except ClientError as err:
+            await self._admin_delete_user_best_effort(client, email)
+            raise TeacherGroupAssignmentError(
+                "Could not assign the new teacher to the teachers group."
+            ) from err
         user_payload = create_response.get("User", {})
         return self._extract_user_sub(user_payload, email)
 
@@ -127,9 +135,32 @@ class CognitoAuthAdapter(AuthServicePort):
 
     @staticmethod
     def _generate_internal_temporary_password(length: int = 20) -> str:
+        """Random temporary password satisfying typical Cognito complexity (mixed classes)."""
+        if length < 8:
+            raise ValueError("temporary password length must be at least 8")
+        rng = secrets.SystemRandom()
         alphabet = string.ascii_letters + string.digits + "!@#$%^&*()-_=+"
-        body = "".join(secrets.choice(alphabet) for _ in range(length))
-        return f"Aa1!{body}"
+        symbol_alphabet = "!@#$%^&*()-_=+"
+        required: list[str] = [
+            rng.choice(string.ascii_uppercase),
+            rng.choice(string.ascii_lowercase),
+            rng.choice(string.digits),
+            rng.choice(symbol_alphabet),
+        ]
+        remaining = length - len(required)
+        chars = required + [rng.choice(alphabet) for _ in range(remaining)]
+        rng.shuffle(chars)
+        return "".join(chars)
+
+    async def _admin_delete_user_best_effort(self, client: Any, username: str) -> None:
+        """Remove a user after a failed provisioning step; ignores delete errors."""
+        try:
+            await client.admin_delete_user(
+                UserPoolId=self._user_pool_id,
+                Username=username,
+            )
+        except ClientError:
+            pass
 
     async def login_teacher(self, *, email: str, password: str) -> AuthTokens:
         if self._injected_client is not None:

--- a/services/exam-api/exam_api/infrastructure/cognito_auth_adapter.py
+++ b/services/exam-api/exam_api/infrastructure/cognito_auth_adapter.py
@@ -111,8 +111,14 @@ class CognitoAuthAdapter(AuthServicePort):
             raise TeacherGroupAssignmentError(
                 "Could not assign the new teacher to the teachers group."
             ) from err
-        user_payload = create_response.get("User", {})
-        return self._extract_user_sub(user_payload, email)
+        try:
+            user_payload = create_response.get("User", {})
+            return self._extract_user_sub(user_payload, email)
+        except RuntimeError as err:
+            await self._admin_delete_user_best_effort(client, email)
+            raise TeacherGroupAssignmentError(
+                "Could not read the new teacher identifier from Cognito."
+            ) from err
 
     @staticmethod
     def _extract_user_sub(user_payload: dict[str, Any], username: str) -> str:

--- a/services/exam-api/exam_api/infrastructure/cognito_auth_adapter.py
+++ b/services/exam-api/exam_api/infrastructure/cognito_auth_adapter.py
@@ -12,6 +12,7 @@ from exam_api.domain.errors import (
     InvalidCredentialsError,
     WeakPasswordError,
 )
+from exam_api.cognito_group_names import COGNITO_TEACHER_GROUP
 from exam_api.ports.auth_service_port import AuthChallenge, AuthServicePort, AuthTokens
 
 
@@ -82,7 +83,7 @@ class CognitoAuthAdapter(AuthServicePort):
         await client.admin_add_user_to_group(
             UserPoolId=self._user_pool_id,
             Username=email,
-            GroupName="teachers",
+            GroupName=COGNITO_TEACHER_GROUP,
         )
         await client.admin_update_user_attributes(
             UserPoolId=self._user_pool_id,

--- a/services/exam-api/exam_api/infrastructure/cognito_auth_adapter.py
+++ b/services/exam-api/exam_api/infrastructure/cognito_auth_adapter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import secrets
+import string
 from typing import Any
 
 import aiobotocore.session
@@ -57,13 +59,18 @@ class CognitoAuthAdapter(AuthServicePort):
         password: str,
         full_name: str,
     ) -> str:
+        # User pool has self-service SignUp disabled (see infra AuthStack). Provision
+        # teachers with AdminCreateUser + permanent password, same idea as student invite.
+        temporary_password = self._generate_internal_temporary_password()
         try:
-            sign_up_response = await client.sign_up(
-                ClientId=self._client_id,
+            create_response = await client.admin_create_user(
+                UserPoolId=self._user_pool_id,
                 Username=email,
-                Password=password,
+                TemporaryPassword=temporary_password,
+                MessageAction="SUPPRESS",
                 UserAttributes=[
                     {"Name": "email", "Value": email},
+                    {"Name": "email_verified", "Value": "true"},
                     {"Name": "name", "Value": full_name},
                 ],
             )
@@ -73,6 +80,17 @@ class CognitoAuthAdapter(AuthServicePort):
                 raise DuplicateEmailError(
                     "A teacher account already exists for this email."
                 ) from err
+            raise
+
+        try:
+            await client.admin_set_user_password(
+                UserPoolId=self._user_pool_id,
+                Username=email,
+                Password=password,
+                Permanent=True,
+            )
+        except ClientError as err:
+            error_code = self._extract_error_code(err)
             if error_code == "InvalidPasswordException":
                 message = err.response.get("Error", {}).get(
                     "Message", "Password does not meet the required policy."
@@ -85,12 +103,33 @@ class CognitoAuthAdapter(AuthServicePort):
             Username=email,
             GroupName=COGNITO_TEACHER_GROUP,
         )
-        await client.admin_update_user_attributes(
-            UserPoolId=self._user_pool_id,
-            Username=email,
-            UserAttributes=[{"Name": "custom:role", "Value": "teacher"}],
+        user_payload = create_response.get("User", {})
+        return self._extract_user_sub(user_payload, email)
+
+    @staticmethod
+    def _extract_user_sub(user_payload: dict[str, Any], username: str) -> str:
+        attributes = user_payload.get("UserAttributes") or user_payload.get(
+            "Attributes", []
         )
-        return str(sign_up_response["UserSub"])
+        if not isinstance(attributes, list):
+            raise RuntimeError(
+                f"Cognito response for {username} does not contain valid attributes."
+            )
+        for attribute in attributes:
+            if not isinstance(attribute, dict):
+                continue
+            if attribute.get("Name") != "sub":
+                continue
+            value = attribute.get("Value")
+            if isinstance(value, str) and value:
+                return value
+        raise RuntimeError(f"Missing Cognito sub for user {username}.")
+
+    @staticmethod
+    def _generate_internal_temporary_password(length: int = 20) -> str:
+        alphabet = string.ascii_letters + string.digits + "!@#$%^&*()-_=+"
+        body = "".join(secrets.choice(alphabet) for _ in range(length))
+        return f"Aa1!{body}"
 
     async def login_teacher(self, *, email: str, password: str) -> AuthTokens:
         if self._injected_client is not None:

--- a/services/exam-api/exam_api/infrastructure/student_invite_adapter.py
+++ b/services/exam-api/exam_api/infrastructure/student_invite_adapter.py
@@ -9,6 +9,7 @@ from typing import Any
 import aiobotocore.session
 from botocore.exceptions import ClientError  # type: ignore[import-untyped]
 
+from exam_api.cognito_group_names import COGNITO_STUDENT_GROUP
 from exam_api.ports.student_invite_port import InviteStudentResult, StudentInviteServicePort
 
 
@@ -105,7 +106,7 @@ class CognitoSesStudentInviteAdapter(StudentInviteServicePort):
         await cognito.admin_add_user_to_group(
             UserPoolId=self._user_pool_id,
             Username=student_email,
-            GroupName="students",
+            GroupName=COGNITO_STUDENT_GROUP,
         )
         await self._send_invitation_email(
             ses,

--- a/services/exam-api/exam_api/infrastructure/student_invite_adapter.py
+++ b/services/exam-api/exam_api/infrastructure/student_invite_adapter.py
@@ -76,7 +76,6 @@ class CognitoSesStudentInviteAdapter(StudentInviteServicePort):
                 UserAttributes=[
                     {"Name": "email", "Value": student_email},
                     {"Name": "email_verified", "Value": "true"},
-                    {"Name": "custom:role", "Value": "student"},
                 ],
             )
             cognito_sub = self._extract_user_sub(response.get("User", {}), student_email)
@@ -87,13 +86,6 @@ class CognitoSesStudentInviteAdapter(StudentInviteServicePort):
             existing_user = await cognito.admin_get_user(
                 UserPoolId=self._user_pool_id,
                 Username=student_email,
-            )
-            await cognito.admin_update_user_attributes(
-                UserPoolId=self._user_pool_id,
-                Username=student_email,
-                UserAttributes=[
-                    {"Name": "custom:role", "Value": "student"},
-                ],
             )
             await cognito.admin_set_user_password(
                 UserPoolId=self._user_pool_id,

--- a/services/exam-api/exam_api/ports/student_invite_port.py
+++ b/services/exam-api/exam_api/ports/student_invite_port.py
@@ -25,8 +25,7 @@ class StudentInviteServicePort(Protocol):
         """Create (or retrieve) a Cognito student account and send invitation email via SES.
 
         - If the student already exists in Cognito: resend the email, do NOT recreate account.
-        - Cognito user must be added to the `students` group.
-        - Cognito custom attributes: `custom:role=student`.
+        - Cognito user must be added to the `students` group (ID token carries cognito:groups).
         - TODO(#10): decide on MessageAction=SUPPRESS + custom SES email vs. Cognito built-in.
         """
         ...

--- a/services/exam-api/tests/test_add_students.py
+++ b/services/exam-api/tests/test_add_students.py
@@ -344,7 +344,7 @@ def students_api_client() -> TestClient:
     jwt_verifier.decode_and_verify_token = AsyncMock(
         return_value={
             "sub": "teacher-1",
-            "custom:role": "teacher",
+            "cognito:groups": ["teachers"],
             "token_use": "id",
         }
     )

--- a/services/exam-api/tests/test_async_migration.py
+++ b/services/exam-api/tests/test_async_migration.py
@@ -25,7 +25,7 @@ def auth_client() -> TestClient:
     app = FastAPI()
     jwt_verifier = create_autospec(JwtVerifierPort, instance=True)
     jwt_verifier.decode_and_verify_token = AsyncMock(
-        return_value={"sub": "admin", "cognito:groups": ["Admin"]}
+        return_value={"sub": "admin", "cognito:groups": ["admin"]}
     )
     app.state.jwt_verifier = jwt_verifier
     app.include_router(router)

--- a/services/exam-api/tests/test_async_migration.py
+++ b/services/exam-api/tests/test_async_migration.py
@@ -6,7 +6,7 @@ test_dynamodb_invite_repository.py, and test_invite_student.py.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, create_autospec
 
 import pytest
 from fastapi import FastAPI
@@ -17,11 +17,17 @@ from exam_api.application.login_teacher import LoginTeacherResult
 from exam_api.application.register_teacher import RegisterTeacherResult
 from exam_api.domain.teacher import Teacher
 from exam_api.ports.auth_service_port import AuthTokens
+from exam_api.ports.jwt_verifier_port import JwtVerifierPort
 
 
 @pytest.fixture
 def auth_client() -> TestClient:
     app = FastAPI()
+    jwt_verifier = create_autospec(JwtVerifierPort, instance=True)
+    jwt_verifier.decode_and_verify_token = AsyncMock(
+        return_value={"sub": "admin", "cognito:groups": ["Admin"]}
+    )
+    app.state.jwt_verifier = jwt_verifier
     app.include_router(router)
     test_client = TestClient(app)
     try:
@@ -45,6 +51,7 @@ def test_register_endpoint_uses_async_execute(auth_client: TestClient) -> None:
 
     response = auth_client.post(
         "/auth/register",
+        headers={"Authorization": "Bearer x"},
         json={"email": "t@example.com", "password": "StrongPassword123!", "full_name": "T"},
     )
 

--- a/services/exam-api/tests/test_auth.py
+++ b/services/exam-api/tests/test_auth.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, create_autospec
 
 import pytest
 from botocore.exceptions import ClientError
@@ -32,9 +32,11 @@ from exam_api.domain.errors import (
     InvalidCredentialsError,
     WeakPasswordError,
 )
+from exam_api.cognito_group_names import COGNITO_TEACHER_GROUP
 from exam_api.domain.teacher import Teacher
 from exam_api.infrastructure.cognito_auth_adapter import CognitoAuthAdapter
 from exam_api.ports.auth_service_port import AuthTokens
+from exam_api.ports.jwt_verifier_port import JwtVerifierPort
 
 
 def _make_client_error(code: str, message: str) -> ClientError:
@@ -58,10 +60,19 @@ def _decode_jwt_payload(token: str) -> dict[str, str]:
     return json.loads(decoded.decode("utf-8"))
 
 
+_ADMIN_JWT_CLAIMS: dict[str, object] = {
+    "sub": "admin-sub",
+    "cognito:groups": ["admin"],
+}
+
+
 @pytest.fixture
 def client() -> TestClient:
     app = FastAPI()
     register_http_error_handlers(app)
+    jwt_verifier = create_autospec(JwtVerifierPort, instance=True)
+    jwt_verifier.decode_and_verify_token = AsyncMock(return_value=_ADMIN_JWT_CLAIMS)
+    app.state.jwt_verifier = jwt_verifier
     app.include_router(router)
     test_client = TestClient(app)
     try:
@@ -187,7 +198,7 @@ async def test_cognito_register_calls_sign_up_and_adds_to_group() -> None:
     cognito.admin_add_user_to_group.assert_awaited_once_with(
         UserPoolId="pool-id",
         Username="teacher@example.com",
-        GroupName="teachers",
+        GroupName=COGNITO_TEACHER_GROUP,
     )
     cognito.admin_update_user_attributes.assert_awaited_once_with(
         UserPoolId="pool-id",
@@ -313,6 +324,7 @@ def test_post_register_201_returns_teacher_id(client: TestClient) -> None:
 
     response = client.post(
         "/auth/register",
+        headers={"Authorization": "Bearer admin-token"},
         json={
             "email": "teacher@example.com",
             "password": "StrongPassword123!",
@@ -335,6 +347,7 @@ def test_post_register_409_duplicate_email(client: TestClient) -> None:
 
     response = client.post(
         "/auth/register",
+        headers={"Authorization": "Bearer admin-token"},
         json={
             "email": "teacher@example.com",
             "password": "StrongPassword123!",
@@ -346,6 +359,52 @@ def test_post_register_409_duplicate_email(client: TestClient) -> None:
     assert response.json()["detail"] == "duplicate"
 
 
+def test_post_register_401_without_bearer(client: TestClient) -> None:
+    mock_use_case = Mock()
+    mock_use_case.execute = AsyncMock()
+    client.app.dependency_overrides[get_register_use_case] = lambda: mock_use_case
+
+    response = client.post(
+        "/auth/register",
+        json={
+            "email": "teacher@example.com",
+            "password": "StrongPassword123!",
+            "full_name": "Ada Lovelace",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json()["code"] == "missing_token"
+    mock_use_case.execute.assert_not_called()
+
+
+def test_post_register_403_without_admin_group(client: TestClient) -> None:
+    mock_use_case = Mock()
+    mock_use_case.execute = AsyncMock()
+    client.app.dependency_overrides[get_register_use_case] = lambda: mock_use_case
+    client.app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
+        return_value={
+            "sub": "teacher-sub",
+            "custom:role": "teacher",
+            "cognito:groups": ["teachers"],
+        }
+    )
+
+    response = client.post(
+        "/auth/register",
+        headers={"Authorization": "Bearer id-token"},
+        json={
+            "email": "teacher@example.com",
+            "password": "StrongPassword123!",
+            "full_name": "Ada Lovelace",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["code"] == "insufficient_role"
+    mock_use_case.execute.assert_not_called()
+
+
 def test_post_register_400_weak_password(client: TestClient) -> None:
     mock_use_case = Mock()
     mock_use_case.execute = AsyncMock(
@@ -355,6 +414,7 @@ def test_post_register_400_weak_password(client: TestClient) -> None:
 
     response = client.post(
         "/auth/register",
+        headers={"Authorization": "Bearer admin-token"},
         json={
             "email": "teacher@example.com",
             "password": "weak",

--- a/services/exam-api/tests/test_auth.py
+++ b/services/exam-api/tests/test_auth.py
@@ -30,6 +30,7 @@ from exam_api.application.register_teacher import (
 from exam_api.domain.errors import (
     DuplicateEmailError,
     InvalidCredentialsError,
+    TeacherGroupAssignmentError,
     WeakPasswordError,
 )
 from exam_api.cognito_group_names import COGNITO_TEACHER_GROUP
@@ -181,6 +182,7 @@ async def test_cognito_register_admin_creates_user_sets_password_adds_to_group()
     )
     cognito.admin_set_user_password = AsyncMock()
     cognito.admin_add_user_to_group = AsyncMock()
+    cognito.admin_delete_user = AsyncMock()
     adapter = CognitoAuthAdapter(
         user_pool_id="pool-id",
         client_id="app-client-id",
@@ -257,6 +259,7 @@ async def test_cognito_register_maps_invalid_password_to_weak_password() -> None
             "Password should contain special characters",
         )
     )
+    cognito.admin_delete_user = AsyncMock()
     adapter = CognitoAuthAdapter(
         user_pool_id="pool-id",
         client_id="app-client-id",
@@ -269,6 +272,63 @@ async def test_cognito_register_maps_invalid_password_to_weak_password() -> None
             password="weak",
             full_name="Ada Lovelace",
         )
+
+    cognito.admin_delete_user.assert_awaited_once_with(
+        UserPoolId="pool-id",
+        Username="teacher@example.com",
+    )
+
+
+@pytest.mark.asyncio
+async def test_cognito_register_group_assignment_failure_deletes_user() -> None:
+    cognito = Mock()
+    cognito.admin_create_user = AsyncMock(
+        return_value={
+            "User": {
+                "Attributes": [
+                    {"Name": "sub", "Value": "teacher-sub-uuid"},
+                ],
+            },
+        }
+    )
+    cognito.admin_set_user_password = AsyncMock()
+    cognito.admin_add_user_to_group = AsyncMock(
+        side_effect=_make_client_error(
+            "LimitExceededException",
+            "Too many requests",
+        )
+    )
+    cognito.admin_delete_user = AsyncMock()
+    adapter = CognitoAuthAdapter(
+        user_pool_id="pool-id",
+        client_id="app-client-id",
+        client=cognito,
+    )
+
+    with pytest.raises(TeacherGroupAssignmentError):
+        await adapter.register_teacher(
+            email="teacher@example.com",
+            password="StrongPassword123!",
+            full_name="Ada Lovelace",
+        )
+
+    cognito.admin_delete_user.assert_awaited_once_with(
+        UserPoolId="pool-id",
+        Username="teacher@example.com",
+    )
+
+
+def test_generate_internal_temporary_password_randomized_and_complex() -> None:
+    seen: set[str] = set()
+    for _ in range(30):
+        pwd = CognitoAuthAdapter._generate_internal_temporary_password(24)
+        assert len(pwd) == 24
+        assert any(c.isupper() for c in pwd)
+        assert any(c.islower() for c in pwd)
+        assert any(c.isdigit() for c in pwd)
+        assert any(c in "!@#$%^&*()-_=+" for c in pwd)
+        seen.add(pwd)
+    assert len(seen) > 1
 
 
 @pytest.mark.asyncio
@@ -441,6 +501,31 @@ def test_post_register_400_weak_password(client: TestClient) -> None:
 
     assert response.status_code == 400
     assert response.json()["detail"] == "Password too weak"
+
+
+def test_post_register_503_teacher_group_assignment_failed(client: TestClient) -> None:
+    mock_use_case = Mock()
+    mock_use_case.execute = AsyncMock(
+        side_effect=TeacherGroupAssignmentError(
+            "Could not assign the new teacher to the teachers group."
+        )
+    )
+    client.app.dependency_overrides[get_register_use_case] = lambda: mock_use_case
+
+    response = client.post(
+        "/auth/register",
+        headers={"Authorization": "Bearer admin-token"},
+        json={
+            "email": "teacher@example.com",
+            "password": "StrongPassword123!",
+            "full_name": "Ada Lovelace",
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == (
+        "Could not assign the new teacher to the teachers group."
+    )
 
 
 def test_post_login_200_returns_tokens(client: TestClient) -> None:

--- a/services/exam-api/tests/test_auth.py
+++ b/services/exam-api/tests/test_auth.py
@@ -318,6 +318,41 @@ async def test_cognito_register_group_assignment_failure_deletes_user() -> None:
     )
 
 
+@pytest.mark.asyncio
+async def test_cognito_register_missing_sub_deletes_user() -> None:
+    """If Cognito omits sub in AdminCreateUser response, roll back and map to domain error."""
+    cognito = Mock()
+    cognito.admin_create_user = AsyncMock(
+        return_value={
+            "User": {
+                "Attributes": [
+                    {"Name": "email", "Value": "teacher@example.com"},
+                ],
+            },
+        }
+    )
+    cognito.admin_set_user_password = AsyncMock()
+    cognito.admin_add_user_to_group = AsyncMock()
+    cognito.admin_delete_user = AsyncMock()
+    adapter = CognitoAuthAdapter(
+        user_pool_id="pool-id",
+        client_id="app-client-id",
+        client=cognito,
+    )
+
+    with pytest.raises(TeacherGroupAssignmentError, match="identifier"):
+        await adapter.register_teacher(
+            email="teacher@example.com",
+            password="StrongPassword123!",
+            full_name="Ada Lovelace",
+        )
+
+    cognito.admin_delete_user.assert_awaited_once_with(
+        UserPoolId="pool-id",
+        Username="teacher@example.com",
+    )
+
+
 def test_generate_internal_temporary_password_randomized_and_complex() -> None:
     seen: set[str] = set()
     for _ in range(30):

--- a/services/exam-api/tests/test_auth.py
+++ b/services/exam-api/tests/test_auth.py
@@ -168,11 +168,19 @@ async def test_login_raises_invalid_credentials_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cognito_register_calls_sign_up_and_adds_to_group() -> None:
+async def test_cognito_register_admin_creates_user_sets_password_adds_to_group() -> None:
     cognito = Mock()
-    cognito.sign_up = AsyncMock(return_value={"UserSub": "teacher-sub-uuid"})
+    cognito.admin_create_user = AsyncMock(
+        return_value={
+            "User": {
+                "Attributes": [
+                    {"Name": "sub", "Value": "teacher-sub-uuid"},
+                ],
+            },
+        }
+    )
+    cognito.admin_set_user_password = AsyncMock()
     cognito.admin_add_user_to_group = AsyncMock()
-    cognito.admin_update_user_attributes = AsyncMock()
     adapter = CognitoAuthAdapter(
         user_pool_id="pool-id",
         client_id="app-client-id",
@@ -186,31 +194,32 @@ async def test_cognito_register_calls_sign_up_and_adds_to_group() -> None:
     )
 
     assert teacher_id == "teacher-sub-uuid"
-    cognito.sign_up.assert_awaited_once_with(
-        ClientId="app-client-id",
+    create_call = cognito.admin_create_user.call_args.kwargs
+    assert create_call["UserPoolId"] == "pool-id"
+    assert create_call["Username"] == "teacher@example.com"
+    assert create_call["MessageAction"] == "SUPPRESS"
+    assert "TemporaryPassword" in create_call
+    user_attrs = create_call["UserAttributes"]
+    assert {"Name": "email", "Value": "teacher@example.com"} in user_attrs
+    assert {"Name": "email_verified", "Value": "true"} in user_attrs
+    assert {"Name": "name", "Value": "Ada Lovelace"} in user_attrs
+    cognito.admin_set_user_password.assert_awaited_once_with(
+        UserPoolId="pool-id",
         Username="teacher@example.com",
         Password="StrongPassword123!",
-        UserAttributes=[
-            {"Name": "email", "Value": "teacher@example.com"},
-            {"Name": "name", "Value": "Ada Lovelace"},
-        ],
+        Permanent=True,
     )
     cognito.admin_add_user_to_group.assert_awaited_once_with(
         UserPoolId="pool-id",
         Username="teacher@example.com",
         GroupName=COGNITO_TEACHER_GROUP,
     )
-    cognito.admin_update_user_attributes.assert_awaited_once_with(
-        UserPoolId="pool-id",
-        Username="teacher@example.com",
-        UserAttributes=[{"Name": "custom:role", "Value": "teacher"}],
-    )
 
 
 @pytest.mark.asyncio
 async def test_cognito_register_maps_username_exists_to_duplicate_email() -> None:
     cognito = Mock()
-    cognito.sign_up = AsyncMock(
+    cognito.admin_create_user = AsyncMock(
         side_effect=_make_client_error(
             "UsernameExistsException",
             "User already exists",
@@ -233,7 +242,16 @@ async def test_cognito_register_maps_username_exists_to_duplicate_email() -> Non
 @pytest.mark.asyncio
 async def test_cognito_register_maps_invalid_password_to_weak_password() -> None:
     cognito = Mock()
-    cognito.sign_up = AsyncMock(
+    cognito.admin_create_user = AsyncMock(
+        return_value={
+            "User": {
+                "Attributes": [
+                    {"Name": "sub", "Value": "sub"},
+                ],
+            },
+        }
+    )
+    cognito.admin_set_user_password = AsyncMock(
         side_effect=_make_client_error(
             "InvalidPasswordException",
             "Password should contain special characters",
@@ -385,7 +403,6 @@ def test_post_register_403_without_admin_group(client: TestClient) -> None:
     client.app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
         return_value={
             "sub": "teacher-sub",
-            "custom:role": "teacher",
             "cognito:groups": ["teachers"],
         }
     )
@@ -475,7 +492,7 @@ def test_jwt_contains_required_claims() -> None:
     header = _encode_segment({"alg": "none", "typ": "JWT"})
     payload = _encode_segment(
         {
-            "custom:role": "teacher",
+            "cognito:groups": ["teachers"],
             "sub": "a1fdb8a9-4f65-4f3d-9f99-984f2634af11",
             "email": "teacher@example.com",
         }
@@ -484,6 +501,6 @@ def test_jwt_contains_required_claims() -> None:
 
     claims = _decode_jwt_payload(token)
 
-    assert claims["custom:role"] == "teacher"
+    assert claims["cognito:groups"] == ["teachers"]
     assert claims["sub"] == "a1fdb8a9-4f65-4f3d-9f99-984f2634af11"
     assert claims["email"] == "teacher@example.com"

--- a/services/exam-api/tests/test_cognito_jwt_verifier.py
+++ b/services/exam-api/tests/test_cognito_jwt_verifier.py
@@ -39,7 +39,7 @@ async def test_decode_and_verify_token_refreshes_jwks_for_unknown_kid(
     decode_mock = Mock(
         return_value={
             "sub": "teacher-1",
-            "custom:role": "teacher",
+            "cognito:groups": ["teachers"],
             "token_use": "id",
         }
     )

--- a/services/exam-api/tests/test_create_exam.py
+++ b/services/exam-api/tests/test_create_exam.py
@@ -191,7 +191,7 @@ def exam_api_client() -> TestClient:
     jwt_verifier.decode_and_verify_token = AsyncMock(
         return_value={
             "sub": "teacher-1",
-            "custom:role": "teacher",
+            "cognito:groups": ["teachers"],
             "token_use": "id",
         }
     )

--- a/services/exam-api/tests/test_exam_config.py
+++ b/services/exam-api/tests/test_exam_config.py
@@ -707,7 +707,7 @@ def config_client_bundle() -> tuple[TestClient, Mock, Mock, Mock]:
     jwt_verifier.decode_and_verify_token = AsyncMock(
         return_value={
             "sub": "teacher-1",
-            "custom:role": "teacher",
+            "cognito:groups": ["teachers"],
             "token_use": "id",
         }
     )

--- a/services/exam-api/tests/test_exam_detail.py
+++ b/services/exam-api/tests/test_exam_detail.py
@@ -450,7 +450,7 @@ def exam_detail_api_client() -> TestClient:
     jwt_verifier.decode_and_verify_token = AsyncMock(
         return_value={
             "sub": "teacher-1",
-            "custom:role": "teacher",
+            "cognito:groups": ["teachers"],
             "token_use": "id",
         },
     )
@@ -557,7 +557,7 @@ def student_statuses_api_client() -> TestClient:
     jwt_verifier.decode_and_verify_token = AsyncMock(
         return_value={
             "sub": "teacher-1",
-            "custom:role": "teacher",
+            "cognito:groups": ["teachers"],
             "token_use": "id",
         },
     )

--- a/services/exam-api/tests/test_invite_student.py
+++ b/services/exam-api/tests/test_invite_student.py
@@ -68,7 +68,7 @@ def client() -> TestClient:
     jwt_verifier.decode_and_verify_token = AsyncMock(
         return_value={
             "sub": "teacher-1",
-            "custom:role": "teacher",
+            "cognito:groups": ["teachers"],
             "token_use": "id",
         }
     )
@@ -311,7 +311,9 @@ async def test_adapter_creates_cognito_user_and_sends_email() -> None:
     cognito.admin_create_user.assert_awaited_once()
     create_call = cognito.admin_create_user.call_args.kwargs
     assert create_call["MessageAction"] == "SUPPRESS"
-    assert {"Name": "custom:role", "Value": "student"} in create_call["UserAttributes"]
+    assert {"Name": "email", "Value": "student@example.com"} in create_call[
+        "UserAttributes"
+    ]
     cognito.admin_add_user_to_group.assert_awaited_once_with(
         UserPoolId="pool-id",
         Username="student@example.com",
@@ -347,7 +349,6 @@ async def test_adapter_handles_existing_user_without_duplicate_account() -> None
             ]
         }
     )
-    cognito.admin_update_user_attributes = AsyncMock()
     cognito.admin_set_user_password = AsyncMock()
     cognito.admin_add_user_to_group = AsyncMock()
     ses.send_email = AsyncMock()
@@ -535,7 +536,7 @@ def test_api_returns_403_for_non_teacher_claim(client: TestClient) -> None:
     client.app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
         return_value={
             "sub": "teacher-1",
-            "custom:role": "student",
+            "cognito:groups": ["students"],
         }
     )
     client.app.dependency_overrides[provide_invite_use_case] = lambda: mock_use_case
@@ -556,7 +557,7 @@ def test_student_scope_endpoint_returns_200_for_matching_student_scope(
     client.app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
         return_value={
             "sub": "student-sub-123",
-            "custom:role": "student",
+            "cognito:groups": ["students"],
             "token_use": "id",
         }
     )
@@ -585,7 +586,7 @@ def test_student_scope_endpoint_returns_403_on_sub_mismatch(client: TestClient) 
     client.app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
         return_value={
             "sub": "student-sub-abc",
-            "custom:role": "student",
+            "cognito:groups": ["students"],
             "token_use": "id",
         }
     )
@@ -605,7 +606,7 @@ def test_student_scope_endpoint_ignores_custom_exam_id_claim(
     client.app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
         return_value={
             "sub": "student-sub-123",
-            "custom:role": "student",
+            "cognito:groups": ["students"],
             "custom:exam_id": "exam-from-token",
             "token_use": "id",
         }
@@ -633,7 +634,7 @@ def test_student_scope_endpoint_returns_404_when_scope_is_missing(
     client.app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
         return_value={
             "sub": "student-sub-123",
-            "custom:role": "student",
+            "cognito:groups": ["students"],
             "token_use": "id",
         }
     )

--- a/services/exam-api/tests/test_rbac_dependencies.py
+++ b/services/exam-api/tests/test_rbac_dependencies.py
@@ -76,7 +76,7 @@ def test_require_teacher_returns_current_teacher(
     rbac_app: FastAPI, rbac_client: TestClient
 ) -> None:
     rbac_app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
-        return_value={"sub": "t1", "custom:role": "teacher"}
+        return_value={"sub": "t1", "cognito:groups": ["teachers"]}
     )
     response = rbac_client.get("/teacher-only", headers={"Authorization": "Bearer x"})
     assert response.status_code == 200
@@ -112,14 +112,14 @@ def test_require_teacher_403_student_role(
     rbac_app: FastAPI, rbac_client: TestClient
 ) -> None:
     rbac_app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
-        return_value={"sub": "x", "custom:role": "student"}
+        return_value={"sub": "x", "cognito:groups": ["students"]}
     )
     response = rbac_client.get("/teacher-only", headers={"Authorization": "Bearer x"})
     assert response.status_code == 403
     assert response.json()["code"] == "insufficient_role"
 
 
-def test_require_teacher_403_missing_role(
+def test_require_teacher_403_missing_teacher_group(
     rbac_app: FastAPI, rbac_client: TestClient
 ) -> None:
     rbac_app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
@@ -156,7 +156,7 @@ def test_require_student_returns_current_student(
     rbac_app: FastAPI, rbac_client: TestClient
 ) -> None:
     rbac_app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
-        return_value={"sub": "s1", "custom:role": "student"}
+        return_value={"sub": "s1", "cognito:groups": ["students"]}
     )
     response = rbac_client.get("/student-only", headers={"Authorization": "Bearer x"})
     assert response.status_code == 200
@@ -190,13 +190,13 @@ def test_require_student_403_teacher_role(
     rbac_app: FastAPI, rbac_client: TestClient
 ) -> None:
     rbac_app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
-        return_value={"sub": "t", "custom:role": "teacher"}
+        return_value={"sub": "t", "cognito:groups": ["teachers"]}
     )
     response = rbac_client.get("/student-only", headers={"Authorization": "Bearer x"})
     assert response.status_code == 403
 
 
-def test_require_student_403_missing_role(
+def test_require_student_403_missing_student_group(
     rbac_app: FastAPI, rbac_client: TestClient
 ) -> None:
     rbac_app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
@@ -208,7 +208,7 @@ def test_require_student_403_missing_role(
 
 def test_require_own_data_passes(rbac_app: FastAPI, rbac_client: TestClient) -> None:
     rbac_app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
-        return_value={"sub": "student-a", "custom:role": "student"}
+        return_value={"sub": "student-a", "cognito:groups": ["students"]}
     )
     response = rbac_client.get(
         "/exams/e1/students/student-a/mine",
@@ -222,7 +222,7 @@ def test_require_own_data_403_mismatch(
     rbac_app: FastAPI, rbac_client: TestClient
 ) -> None:
     rbac_app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
-        return_value={"sub": "student-a", "custom:role": "student"}
+        return_value={"sub": "student-a", "cognito:groups": ["students"]}
     )
     response = rbac_client.get(
         "/exams/e1/students/other/mine",

--- a/services/exam-api/tests/test_rbac_dependencies.py
+++ b/services/exam-api/tests/test_rbac_dependencies.py
@@ -152,6 +152,24 @@ def test_require_admin_403_without_admin_group(
     assert response.json()["code"] == "insufficient_role"
 
 
+def test_require_admin_403_missing_groups_claim(
+    rbac_app: FastAPI, rbac_client: TestClient
+) -> None:
+    rbac_app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
+        return_value={"sub": "x"}
+    )
+    response = rbac_client.get("/admin-only", headers={"Authorization": "Bearer x"})
+    assert response.status_code == 403
+    assert response.json()["code"] == "insufficient_role"
+
+
+def test_require_admin_401_missing_auth(rbac_client: TestClient) -> None:
+    response = rbac_client.get("/admin-only")
+    assert response.status_code == 401
+    body = response.json()
+    assert body["code"] == "missing_token"
+
+
 def test_require_student_returns_current_student(
     rbac_app: FastAPI, rbac_client: TestClient
 ) -> None:

--- a/services/exam-api/tests/test_rbac_dependencies.py
+++ b/services/exam-api/tests/test_rbac_dependencies.py
@@ -12,8 +12,10 @@ from httpx import HTTPError
 from jose import JWTError
 
 from exam_api.api.dependencies import (
+    CurrentAdmin,
     CurrentStudent,
     CurrentTeacher,
+    require_admin,
     require_own_data,
     require_student,
     require_teacher,
@@ -49,6 +51,12 @@ def rbac_app() -> FastAPI:
         _: Annotated[CurrentStudent, Depends(require_student)],
     ) -> dict[str, str]:
         return {"role": "student"}
+
+    @app.get("/admin-only")
+    async def admin_route(
+        _: Annotated[CurrentAdmin, Depends(require_admin)],
+    ) -> dict[str, str]:
+        return {"role": "admin"}
 
     @app.get("/exams/{exam_id}/students/{student_id}/mine")
     async def own_route(
@@ -118,6 +126,28 @@ def test_require_teacher_403_missing_role(
         return_value={"sub": "x"}
     )
     response = rbac_client.get("/teacher-only", headers={"Authorization": "Bearer x"})
+    assert response.status_code == 403
+    assert response.json()["code"] == "insufficient_role"
+
+
+def test_require_admin_returns_when_group_present(
+    rbac_app: FastAPI, rbac_client: TestClient
+) -> None:
+    rbac_app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
+        return_value={"sub": "a1", "cognito:groups": ["Admin"]}
+    )
+    response = rbac_client.get("/admin-only", headers={"Authorization": "Bearer x"})
+    assert response.status_code == 200
+    assert response.json() == {"role": "admin"}
+
+
+def test_require_admin_403_without_admin_group(
+    rbac_app: FastAPI, rbac_client: TestClient
+) -> None:
+    rbac_app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
+        return_value={"sub": "t", "cognito:groups": ["teachers"]}
+    )
+    response = rbac_client.get("/admin-only", headers={"Authorization": "Bearer x"})
     assert response.status_code == 403
     assert response.json()["code"] == "insufficient_role"
 

--- a/services/exam-api/tests/test_rbac_dependencies.py
+++ b/services/exam-api/tests/test_rbac_dependencies.py
@@ -134,7 +134,7 @@ def test_require_admin_returns_when_group_present(
     rbac_app: FastAPI, rbac_client: TestClient
 ) -> None:
     rbac_app.state.jwt_verifier.decode_and_verify_token = AsyncMock(
-        return_value={"sub": "a1", "cognito:groups": ["Admin"]}
+        return_value={"sub": "a1", "cognito:groups": ["admin"]}
     )
     response = rbac_client.get("/admin-only", headers={"Authorization": "Bearer x"})
     assert response.status_code == 200

--- a/services/exam-api/tests/test_student_auth.py
+++ b/services/exam-api/tests/test_student_auth.py
@@ -541,7 +541,7 @@ async def test_student_id_token_from_challenge_response_contains_claims() -> Non
     header = _encode_segment({"alg": "none", "typ": "JWT"})
     payload = _encode_segment(
         {
-            "custom:role": "student",
+            "cognito:groups": ["students"],
             "sub": "student-sub-uuid",
             "email": "student@school.edu",
             "custom:exam_id": "exam-123",
@@ -573,7 +573,7 @@ async def test_student_id_token_from_challenge_response_contains_claims() -> Non
 
     claims = _decode_jwt_payload(tokens.id_token)
 
-    assert claims["custom:role"] == "student"
+    assert claims["cognito:groups"] == ["students"]
     assert claims["sub"] == "student-sub-uuid"
     assert claims["email"] == "student@school.edu"
     assert claims["custom:exam_id"] == "exam-123"

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ members = [
     "batch-poller",
     "exam-api",
     "grading-cloud",
+    "grading-infra",
     "grading-shared",
     "pdf-generator",
     "spreadsheet-converter",
@@ -191,6 +192,66 @@ wheels = [
 ]
 
 [[package]]
+name = "aws-cdk-asset-awscli-v1"
+version = "2.2.273"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsii" },
+    { name = "publication" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/11/925a1ae8dd7c9fd7e775b405f357970bdf975f54550923c6c755ac24a00d/aws_cdk_asset_awscli_v1-2.2.273.tar.gz", hash = "sha256:6580dad3416e53712db434f81add6fb4a314e1a80f9c57cc42606df1f64c8e0f", size = 20370823, upload-time = "2026-03-30T16:58:42.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/eb/817ecd9e0987465114d17808bb8d10907ef64c9ea6029addfab0ab9aa055/aws_cdk_asset_awscli_v1-2.2.273-py3-none-any.whl", hash = "sha256:1a0994afa7b48f63b580603be64c7a99d19ed6777bdf81d3c2435d8b43cf0d71", size = 20369281, upload-time = "2026-03-30T16:58:39.474Z" },
+]
+
+[[package]]
+name = "aws-cdk-asset-node-proxy-agent-v6"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsii" },
+    { name = "publication" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/4b/0ccc9d12f66becaaf489e55d152f50376817cd808cf4068c0c5385d21c9d/aws_cdk_asset_node_proxy_agent_v6-2.1.1.tar.gz", hash = "sha256:37211fea7e308144d20666b939d8763d733000d8d837ba968dacaf4983daf574", size = 1542241, upload-time = "2026-02-26T16:38:43.95Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/b1/775c53a017d30d6bb0c9fa19182df11672569b6c8c7c1a1b325639abff63/aws_cdk_asset_node_proxy_agent_v6-2.1.1-py3-none-any.whl", hash = "sha256:a24fab484423fcb7c729fb376817a4dbb6a09c176243fd1dcbdaa05ddf62f037", size = 1540751, upload-time = "2026-02-26T16:38:42.464Z" },
+]
+
+[[package]]
+name = "aws-cdk-cloud-assembly-schema"
+version = "53.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsii" },
+    { name = "publication" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/8a/3b94fbba0d8ca4123eb015ea12a1c8fc5193a1eddcc4d69d31b9575546c8/aws_cdk_cloud_assembly_schema-53.20.0.tar.gz", hash = "sha256:c5d884f7211fd18cc0ce8c4349902ab6a6b3cd8f3c2259c56616a59218c221eb", size = 212292, upload-time = "2026-04-30T11:34:29.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/eb/7bf100ad3603d5fbbebb49b3d48add58abda59c3fa44a4a7eae40da5b8d0/aws_cdk_cloud_assembly_schema-53.20.0-py3-none-any.whl", hash = "sha256:b68ea0754ec830751d4a375ebe84d4c077dc488a2498c3607a2f998bc7e91d73", size = 212140, upload-time = "2026-04-30T11:34:27.044Z" },
+]
+
+[[package]]
+name = "aws-cdk-lib"
+version = "2.252.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aws-cdk-asset-awscli-v1" },
+    { name = "aws-cdk-asset-node-proxy-agent-v6" },
+    { name = "aws-cdk-cloud-assembly-schema" },
+    { name = "constructs" },
+    { name = "jsii" },
+    { name = "publication" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/2e/468ed756570af782831bc0518b4f187773b036342ce1b6f3d4e13e6127d8/aws_cdk_lib-2.252.0.tar.gz", hash = "sha256:2498d771ab141599c48494bd2564ee9a4fbaade54befa9356811e9454616d0a0", size = 49479070, upload-time = "2026-04-30T12:31:54.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/94/32c21ad93dc21554286955fd5ebc68cb91149cc5f7f3154b07927c3fc693/aws_cdk_lib-2.252.0-py3-none-any.whl", hash = "sha256:c96d02582d344ee81ea2ef8a5e22b6e680789973804720ec9f0e95a050257db1", size = 50157828, upload-time = "2026-04-30T12:31:11.041Z" },
+]
+
+[[package]]
 name = "batch-poller"
 version = "0.1.0"
 source = { editable = "services/batch-poller" }
@@ -227,6 +288,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/bc/a4b7c46471c2e789ad8c4c7acfd7f302fdb481d93ff870f441249b924ae6/botocore-1.42.91.tar.gz", hash = "sha256:d252e27bc454afdbf5ed3dc617aa423f2c855c081e98b7963093399483ecc698", size = 15213010, upload-time = "2026-04-17T19:30:50.793Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/fc/24cc0a47c824f13933e210e9ad034b4fba22f7185b8d904c0fbf5a3b2be8/botocore-1.42.91-py3-none-any.whl", hash = "sha256:7a28c3cc6bfab5724ad18899d52402b776a0de7d87fa20c3c5270bcaaf199ce8", size = 14897344, upload-time = "2026-04-17T19:30:44.245Z" },
+]
+
+[[package]]
+name = "cattrs"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/00/2432bb2d445b39b5407f0a90e01b9a271475eea7caf913d7a86bcb956385/cattrs-25.3.0.tar.gz", hash = "sha256:1ac88d9e5eda10436c4517e390a4142d88638fe682c436c93db7ce4a277b884a", size = 509321, upload-time = "2025-10-07T12:26:08.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/2b/a40e1488fdfa02d3f9a653a61a5935ea08b3c2225ee818db6a76c7ba9695/cattrs-25.3.0-py3-none-any.whl", hash = "sha256:9896e84e0a5bf723bc7b4b68f4481785367ce07a8a02e7e9ee6eb2819bc306ff", size = 70738, upload-time = "2025-10-07T12:26:06.603Z" },
 ]
 
 [[package]]
@@ -314,6 +388,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "constructs"
+version = "10.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsii" },
+    { name = "publication" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/f57364d14c818108a47e124d1a4cfbee7c9f69ab1263ab59a7087028be18/constructs-10.6.0.tar.gz", hash = "sha256:bc55d1d390142424861e5ff5c6b8c243c4bae18fe7302e0939c2003f329ba365", size = 68788, upload-time = "2026-03-23T09:00:54.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/38/6de46d122a2fcd275a5f1fa4ad1d8d2058afd6b72d8db5f0c125515cbb5c/constructs-10.6.0-py3-none-any.whl", hash = "sha256:ad4ffabdb53c17cde00fb94e441a1ba9fddac57c92ad49d263f8dbd416cec513", size = 66969, upload-time = "2026-03-23T09:00:53.041Z" },
 ]
 
 [[package]]
@@ -542,6 +630,8 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "exam-api" },
+    { name = "grading-infra" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -552,10 +642,39 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "exam-api", editable = "services/exam-api" },
+    { name = "grading-infra", editable = "infra" },
     { name = "mypy", specifier = ">=1.20.2" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.15.12" },
+]
+
+[[package]]
+name = "grading-infra"
+version = "0.1.0"
+source = { editable = "infra" }
+dependencies = [
+    { name = "aws-cdk-lib" },
+    { name = "constructs" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aws-cdk-lib", specifier = ">=2.200.0" },
+    { name = "constructs", specifier = ">=10.0.0,<11.0.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
 ]
 
 [[package]]
@@ -645,6 +764,15 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -660,6 +788,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "jsii"
+version = "1.129.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "importlib-resources" },
+    { name = "publication" },
+    { name = "python-dateutil" },
+    { name = "typeguard" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/da/a9c77b0c99e0f1645fd9186705928c81015a630f16972c734051bb800b09/jsii-1.129.0.tar.gz", hash = "sha256:94e73a9fa5412442d26a0d70500f261b21863063eb747b3732ae7665c630b54e", size = 445195, upload-time = "2026-04-30T17:09:00.709Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/4e/163eecb4e2e73fed481504f1858c4c0be0917832bc0b954767dff3db44ff/jsii-1.129.0-py3-none-any.whl", hash = "sha256:96b142f83467e442948007426819e4998b8eac0f756bcf325fee68563c0b7ca0", size = 418376, upload-time = "2026-04-30T17:08:59.075Z" },
 ]
 
 [[package]]
@@ -996,6 +1142,15 @@ wheels = [
 ]
 
 [[package]]
+name = "publication"
+version = "0.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/8e/8c9fe7e32fdf9c386f83d59610cc819a25dadb874b5920f2d0ef7d35f46d/publication-0.0.3.tar.gz", hash = "sha256:68416a0de76dddcdd2930d1c8ef853a743cc96c82416c4e4d3b5d901c6276dc4", size = 5484, upload-time = "2019-01-15T07:52:23.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/d3/6308debad7afcdb3ea5f50b4b3d852f41eb566a311fbcb4da23755a28155/publication-0.0.3-py2.py3-none-any.whl", hash = "sha256:0248885351febc11d8a1098d5c8e3ab2dabcf3e8c0c96db1e17ecd12b53afbe6", size = 7687, upload-time = "2019-01-15T07:52:22.151Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1307,6 +1462,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "typeguard"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/38/c61bfcf62a7b572b5e9363a802ff92559cb427ee963048e1442e3aef7490/typeguard-2.13.3.tar.gz", hash = "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4", size = 40604, upload-time = "2021-12-10T21:09:39.158Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/bb/d43e5c75054e53efce310e79d63df0ac3f25e34c926be5dffb7d283fb2a8/typeguard-2.13.3-py3-none-any.whl", hash = "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1", size = 17605, upload-time = "2021-12-10T21:09:37.844Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds an `admin` Cognito group in the User Pool and enforces **group-based** RBAC in exam-api: registering teachers requires an admin JWT with `cognito:groups` including `admin`. Teacher and student access continues to use Cognito group membership instead of custom attributes.

## What changed

### Infrastructure (`infra/stacks/auth_stack.py`)
- Creates the `admin` group alongside existing groups; tests updated in `infra/tests/test_auth_stack.py`.

### Exam API
- **Auth**: `require_admin` dependency; dependencies refactored to validate roles via Cognito groups (`cognito_auth_adapter`, `dependencies.py`).
- **Constants**: `cognito_group_names.py` for consistent lowercase group names (`admin`, `teachers`, etc.).
- **Student invite port/adapter**: minor alignment with the group-based model.
- **Docs**: `services/exam-api/docs/api.http` documents admin token flow for `Register Teacher`.

### Tests
- Broad updates across auth, RBAC, invite-student, and related suites to match group-based checks.

## How to verify locally

1. Deploy or use a stack where the `admin` group exists; create a user in `admin` and obtain an `id_token`.
2. Call `POST /auth/register/teacher` with `Authorization: Bearer <admin id_token>` — expect 201.
3. Non-admin tokens should be rejected on admin-only routes.

## Notes for reviewers

- **Breaking / ops**: Existing deployments need the new Cognito group; teacher registration from the API now **requires** an admin caller (see api.http comments).
- Third commit standardizes naming and docs; fourth iteration removes custom-attribute role usage in favor of groups end-to-end.

Made with [Cursor](https://cursor.com)