### PR TITLE
infra(#5): Lambda functions, EventBridge Scheduler group and SSM wiring

### DIFF
--- a/infra/stacks/compute_stack.py
+++ b/infra/stacks/compute_stack.py
@@ -6,12 +6,27 @@ from aws_cdk import aws_ecs as ecs
 from aws_cdk import aws_elasticloadbalancingv2 as elbv2
 from aws_cdk import aws_events as events
 from aws_cdk import aws_iam as iam
+from aws_cdk import aws_lambda as lambda_
+from aws_cdk import aws_lambda_event_sources as lambda_event_sources
 from aws_cdk import aws_logs as logs
 from aws_cdk import aws_s3 as s3
+from aws_cdk import aws_scheduler as scheduler
 from aws_cdk import aws_secretsmanager as secretsmanager
 from aws_cdk import aws_sqs as sqs
 from aws_cdk import aws_ssm as ssm
 from constructs import Construct
+
+BATCH_POLLERS_SCHEDULE_GROUP_NAME = "grading-batch-pollers"
+
+# Inline placeholder for the batch-poller Lambda. The real implementation ships
+# as a zip via CI; this stub only exists so CDK can synth before the first
+# deploy.
+_BATCH_POLLER_PLACEHOLDER_CODE = (
+    "def handler(event, context):\n"
+    "    raise NotImplementedError("
+    "'batch-poller code is uploaded by CI; replace via aws lambda update-function-code'"
+    ")\n"
+)
 
 
 class ComputeStack(Stack):
@@ -173,6 +188,121 @@ class ComputeStack(Stack):
             parameter_name="/grading/messaging/pdf-generation-queue-url",
             string_value=pdf_generation_queue.queue_url,
         )
+
+        # ── Lambdas ──────────────────────────────────────────────────────────
+        # Explicit log groups (the deprecated `log_retention=` shim spawns a
+        # custom-resource Lambda; pre-creating the group is the modern path).
+        spreadsheet_converter_log_group = logs.LogGroup(
+            self,
+            "SpreadsheetConverterLogGroup",
+            log_group_name="/aws/lambda/grading-spreadsheet-converter",
+            retention=logs.RetentionDays.ONE_MONTH,
+        )
+        pdf_generator_log_group = logs.LogGroup(
+            self,
+            "PdfGeneratorLogGroup",
+            log_group_name="/aws/lambda/grading-pdf-generator",
+            retention=logs.RetentionDays.ONE_MONTH,
+        )
+        batch_poller_log_group = logs.LogGroup(
+            self,
+            "BatchPollerLogGroup",
+            log_group_name="/aws/lambda/grading-batch-poller",
+            retention=logs.RetentionDays.ONE_MONTH,
+        )
+
+        # Container image Lambda — consumes spreadsheet-conversion queue.
+        spreadsheet_converter_lambda = lambda_.DockerImageFunction(
+            self,
+            "SpreadsheetConverterLambda",
+            function_name="grading-spreadsheet-converter",
+            code=lambda_.DockerImageCode.from_ecr(
+                self.spreadsheet_converter_repository, tag_or_digest="latest"
+            ),
+            memory_size=512,
+            timeout=Duration.seconds(300),
+            environment={
+                "FILES_BUCKET_NAME": files_bucket.bucket_name,
+                "PIPELINE_EVENTS_QUEUE_URL": pipeline_events_queue.queue_url,
+            },
+            log_group=spreadsheet_converter_log_group,
+        )
+        spreadsheet_converter_lambda.add_event_source(
+            lambda_event_sources.SqsEventSource(
+                spreadsheet_conversion_queue, batch_size=1
+            )
+        )
+        files_bucket.grant_read_write(spreadsheet_converter_lambda)
+        pipeline_events_queue.grant_send_messages(spreadsheet_converter_lambda)
+
+        # Container image Lambda — consumes pdf-generation queue.
+        pdf_generator_lambda = lambda_.DockerImageFunction(
+            self,
+            "PdfGeneratorLambda",
+            function_name="grading-pdf-generator",
+            code=lambda_.DockerImageCode.from_ecr(
+                self.pdf_generator_repository, tag_or_digest="latest"
+            ),
+            memory_size=1024,
+            timeout=Duration.seconds(300),
+            environment={
+                "FILES_BUCKET_NAME": files_bucket.bucket_name,
+                "PIPELINE_EVENTS_QUEUE_URL": pipeline_events_queue.queue_url,
+            },
+            log_group=pdf_generator_log_group,
+        )
+        pdf_generator_lambda.add_event_source(
+            lambda_event_sources.SqsEventSource(pdf_generation_queue, batch_size=1)
+        )
+        files_bucket.grant_read_write(pdf_generator_lambda)
+        pipeline_events_queue.grant_send_messages(pdf_generator_lambda)
+
+        # Zip Lambda — invoked by EventBridge Scheduler (one rule per active batch).
+        # Not subscribed to any queue.
+        batch_poller_lambda = lambda_.Function(
+            self,
+            "BatchPollerLambda",
+            function_name="grading-batch-poller",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            handler="handler.handler",
+            code=lambda_.Code.from_inline(_BATCH_POLLER_PLACEHOLDER_CODE),
+            memory_size=256,
+            timeout=Duration.seconds(60),
+            environment={
+                "FILES_BUCKET_NAME": files_bucket.bucket_name,
+                "PIPELINE_EVENTS_QUEUE_URL": pipeline_events_queue.queue_url,
+            },
+            log_group=batch_poller_log_group,
+        )
+        files_bucket.grant_read_write(batch_poller_lambda)
+        pipeline_events_queue.grant_send_messages(batch_poller_lambda)
+
+        # ── EventBridge Scheduler ────────────────────────────────────────────
+        # The schedule group is pre-created here; individual schedules (one per
+        # active Anthropic batch) are created/deleted dynamically by exam-api.
+        batch_pollers_schedule_group = scheduler.CfnScheduleGroup(
+            self,
+            "BatchPollersScheduleGroup",
+            name=BATCH_POLLERS_SCHEDULE_GROUP_NAME,
+        )
+
+        # Role assumed by EventBridge Scheduler when invoking the batch-poller
+        # Lambda. exam-api passes this ARN as the `RoleArn` on each schedule.
+        batch_poller_scheduler_role = iam.Role(
+            self,
+            "BatchPollerSchedulerRole",
+            role_name="grading-batch-poller-scheduler-role",
+            assumed_by=iam.ServicePrincipal(
+                "scheduler.amazonaws.com",
+                conditions={
+                    "StringEquals": {"aws:SourceAccount": self.account},
+                },
+            ),
+            description=(
+                "Assumed by EventBridge Scheduler to invoke the batch-poller Lambda."
+            ),
+        )
+        batch_poller_lambda.grant_invoke(batch_poller_scheduler_role)
 
         # ── EventBridge ──────────────────────────────────────────────────────
         event_bus = events.EventBus(
@@ -344,6 +474,60 @@ class ComputeStack(Stack):
                 resources=[event_bus.event_bus_arn],
             )
         )
+        # exam-api creates/deletes schedules dynamically (one per active batch),
+        # scoped to the batch-pollers group only.
+        task_role.add_to_principal_policy(
+            iam.PolicyStatement(
+                sid="SchedulerAccess",
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "scheduler:CreateSchedule",
+                    "scheduler:DeleteSchedule",
+                    "scheduler:GetSchedule",
+                    "scheduler:UpdateSchedule",
+                ],
+                resources=[
+                    f"arn:aws:scheduler:{self.region}:{self.account}"
+                    f":schedule/{BATCH_POLLERS_SCHEDULE_GROUP_NAME}/*"
+                ],
+            )
+        )
+        # PassRole is required so exam-api can hand the scheduler role over to
+        # EventBridge Scheduler when creating each schedule.
+        task_role.add_to_principal_policy(
+            iam.PolicyStatement(
+                sid="SchedulerPassRole",
+                effect=iam.Effect.ALLOW,
+                actions=["iam:PassRole"],
+                resources=[batch_poller_scheduler_role.role_arn],
+                conditions={
+                    "StringEquals": {
+                        "iam:PassedToService": "scheduler.amazonaws.com"
+                    }
+                },
+            )
+        )
+
+        # exam-api needs the batch-poller Lambda ARN to point new scheduler rules
+        # at it, plus the schedule group name and the role Scheduler assumes.
+        ssm.StringParameter(
+            self,
+            "BatchPollerLambdaArnParam",
+            parameter_name="/grading/lambda/batch-poller-arn",
+            string_value=batch_poller_lambda.function_arn,
+        )
+        ssm.StringParameter(
+            self,
+            "BatchPollersScheduleGroupNameParam",
+            parameter_name="/grading/scheduler/batch-pollers-group-name",
+            string_value=BATCH_POLLERS_SCHEDULE_GROUP_NAME,
+        )
+        ssm.StringParameter(
+            self,
+            "BatchPollerSchedulerRoleArnParam",
+            parameter_name="/grading/scheduler/batch-poller-role-arn",
+            string_value=batch_poller_scheduler_role.role_arn,
+        )
 
         # ── Outputs ───────────────────────────────────────────────────────────
         CfnOutput(
@@ -399,4 +583,22 @@ class ComputeStack(Stack):
             "PublicSubnetIds",
             value=",".join([s.subnet_id for s in vpc.public_subnets]),
             export_name="GradingPublicSubnetIds",
+        )
+        CfnOutput(
+            self,
+            "BatchPollerLambdaArn",
+            value=batch_poller_lambda.function_arn,
+            export_name="GradingBatchPollerLambdaArn",
+        )
+        CfnOutput(
+            self,
+            "BatchPollersScheduleGroupName",
+            value=batch_pollers_schedule_group.name or BATCH_POLLERS_SCHEDULE_GROUP_NAME,
+            export_name="GradingBatchPollersScheduleGroupName",
+        )
+        CfnOutput(
+            self,
+            "BatchPollerSchedulerRoleArn",
+            value=batch_poller_scheduler_role.role_arn,
+            export_name="GradingBatchPollerSchedulerRoleArn",
         )

--- a/infra/stacks/compute_stack.py
+++ b/infra/stacks/compute_stack.py
@@ -1,4 +1,4 @@
-from aws_cdk import CfnOutput, CfnParameter, Duration, Stack
+from aws_cdk import CfnOutput, CfnParameter, Duration, RemovalPolicy, Stack
 from aws_cdk import aws_cloudwatch as cloudwatch
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecr as ecr
@@ -192,23 +192,29 @@ class ComputeStack(Stack):
         # ── Lambdas ──────────────────────────────────────────────────────────
         # Explicit log groups (the deprecated `log_retention=` shim spawns a
         # custom-resource Lambda; pre-creating the group is the modern path).
+        # removal_policy=DESTROY so `cdk destroy` cleans up the groups; without
+        # it, the default RETAIN orphans them and a subsequent `cdk deploy`
+        # fails on "ResourceAlreadyExists".
         spreadsheet_converter_log_group = logs.LogGroup(
             self,
             "SpreadsheetConverterLogGroup",
             log_group_name="/aws/lambda/grading-spreadsheet-converter",
             retention=logs.RetentionDays.ONE_MONTH,
+            removal_policy=RemovalPolicy.DESTROY,
         )
         pdf_generator_log_group = logs.LogGroup(
             self,
             "PdfGeneratorLogGroup",
             log_group_name="/aws/lambda/grading-pdf-generator",
             retention=logs.RetentionDays.ONE_MONTH,
+            removal_policy=RemovalPolicy.DESTROY,
         )
         batch_poller_log_group = logs.LogGroup(
             self,
             "BatchPollerLogGroup",
             log_group_name="/aws/lambda/grading-batch-poller",
             retention=logs.RetentionDays.ONE_MONTH,
+            removal_policy=RemovalPolicy.DESTROY,
         )
 
         # Container image Lambda — consumes spreadsheet-conversion queue.
@@ -288,6 +294,14 @@ class ComputeStack(Stack):
 
         # Role assumed by EventBridge Scheduler when invoking the batch-poller
         # Lambda. exam-api passes this ARN as the `RoleArn` on each schedule.
+        # SourceAccount + SourceArn scope the trust to schedules created in our
+        # account AND inside the batch-pollers group only — defends against the
+        # confused-deputy pattern where another account/group could trick
+        # Scheduler into assuming this role.
+        batch_pollers_group_arn = (
+            f"arn:aws:scheduler:{self.region}:{self.account}"
+            f":schedule/{BATCH_POLLERS_SCHEDULE_GROUP_NAME}/*"
+        )
         batch_poller_scheduler_role = iam.Role(
             self,
             "BatchPollerSchedulerRole",
@@ -296,6 +310,7 @@ class ComputeStack(Stack):
                 "scheduler.amazonaws.com",
                 conditions={
                     "StringEquals": {"aws:SourceAccount": self.account},
+                    "ArnLike": {"aws:SourceArn": batch_pollers_group_arn},
                 },
             ),
             description=(

--- a/infra/tests/test_compute_stack.py
+++ b/infra/tests/test_compute_stack.py
@@ -260,3 +260,304 @@ def test_no_iam_action_on_dlqs(compute_template: Template) -> None:
                         f"references DLQ {referenced_logical_id} — DLQs must "
                         "only be reachable via redrive policy."
                     )
+
+
+# ── Lambdas ─────────────────────────────────────────────────────────────────
+
+
+def test_three_lambda_functions_total(compute_template: Template) -> None:
+    # spreadsheet-converter + pdf-generator + batch-poller
+    compute_template.resource_count_is("AWS::Lambda::Function", 3)
+
+
+def test_spreadsheet_converter_lambda_config(compute_template: Template) -> None:
+    compute_template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "FunctionName": "grading-spreadsheet-converter",
+            "PackageType": "Image",
+            "MemorySize": 512,
+            "Timeout": 300,
+        },
+    )
+
+
+def test_pdf_generator_lambda_config(compute_template: Template) -> None:
+    compute_template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "FunctionName": "grading-pdf-generator",
+            "PackageType": "Image",
+            "MemorySize": 1024,
+            "Timeout": 300,
+        },
+    )
+
+
+def test_batch_poller_lambda_config(compute_template: Template) -> None:
+    """batch-poller is a zip-deployed Python Lambda — NOT a container."""
+    compute_template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "FunctionName": "grading-batch-poller",
+            "Runtime": "python3.12",
+            "Handler": "handler.handler",
+            "MemorySize": 256,
+            "Timeout": 60,
+        },
+    )
+
+
+def test_batch_poller_lambda_is_not_a_container(compute_template: Template) -> None:
+    """batch-poller must NOT have PackageType=Image (it's a zip Lambda)."""
+    functions = compute_template.find_resources(
+        "AWS::Lambda::Function",
+        {
+            "Properties": Match.object_like(
+                {"FunctionName": "grading-batch-poller"}
+            )
+        },
+    )
+    assert len(functions) == 1, "Expected exactly one batch-poller Lambda"
+    props = next(iter(functions.values()))["Properties"]
+    assert props.get("PackageType") != "Image"
+
+
+# ── SQS event sources ───────────────────────────────────────────────────────
+
+
+def test_two_lambda_event_source_mappings(compute_template: Template) -> None:
+    """Only the two container Lambdas are SQS-triggered. batch-poller is
+    invoked by EventBridge Scheduler (no event-source mapping)."""
+    compute_template.resource_count_is("AWS::Lambda::EventSourceMapping", 2)
+
+
+@pytest.mark.parametrize(
+    "queue_logical_prefix",
+    ["SpreadsheetConversionQueue", "PdfGenerationQueue"],
+)
+def test_sqs_event_source_batch_size_one(
+    compute_template: Template, queue_logical_prefix: str
+) -> None:
+    compute_template.has_resource_properties(
+        "AWS::Lambda::EventSourceMapping",
+        {
+            "BatchSize": 1,
+            "EventSourceArn": {
+                "Fn::GetAtt": [
+                    Match.string_like_regexp(queue_logical_prefix),
+                    "Arn",
+                ]
+            },
+        },
+    )
+
+
+# ── EventBridge Scheduler ───────────────────────────────────────────────────
+
+
+def test_batch_pollers_schedule_group_exists(compute_template: Template) -> None:
+    compute_template.has_resource_properties(
+        "AWS::Scheduler::ScheduleGroup",
+        {"Name": "grading-batch-pollers"},
+    )
+
+
+def test_no_individual_schedules_provisioned(compute_template: Template) -> None:
+    """Per-batch schedules are created at runtime by exam-api, never via CDK."""
+    compute_template.resource_count_is("AWS::Scheduler::Schedule", 0)
+
+
+def test_scheduler_role_trusts_scheduler_service(compute_template: Template) -> None:
+    compute_template.has_resource_properties(
+        "AWS::IAM::Role",
+        {
+            "RoleName": "grading-batch-poller-scheduler-role",
+            "AssumeRolePolicyDocument": Match.object_like(
+                {
+                    "Statement": Match.array_with(
+                        [
+                            Match.object_like(
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "sts:AssumeRole",
+                                    "Principal": {
+                                        "Service": "scheduler.amazonaws.com"
+                                    },
+                                    "Condition": {
+                                        "StringEquals": Match.object_like(
+                                            {"aws:SourceAccount": Match.any_value()}
+                                        )
+                                    },
+                                }
+                            )
+                        ]
+                    )
+                }
+            ),
+        },
+    )
+
+
+def test_scheduler_role_can_invoke_only_batch_poller(
+    compute_template: Template,
+) -> None:
+    """Scheduler role must invoke ONLY the batch-poller Lambda."""
+    compute_template.has_resource_properties(
+        "AWS::IAM::Policy",
+        {
+            "PolicyDocument": Match.object_like(
+                {
+                    "Statement": Match.array_with(
+                        [
+                            Match.object_like(
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "lambda:InvokeFunction",
+                                    "Resource": Match.array_with(
+                                        [
+                                            {
+                                                "Fn::GetAtt": [
+                                                    Match.string_like_regexp(
+                                                        "BatchPollerLambda"
+                                                    ),
+                                                    "Arn",
+                                                ]
+                                            }
+                                        ]
+                                    ),
+                                }
+                            )
+                        ]
+                    )
+                }
+            ),
+            "Roles": Match.array_with(
+                [{"Ref": Match.string_like_regexp("BatchPollerSchedulerRole")}]
+            ),
+        },
+    )
+
+
+# ── exam-api task role: scheduler API + PassRole ────────────────────────────
+
+
+def test_exam_api_can_manage_schedules_in_batch_pollers_group(
+    compute_template: Template,
+) -> None:
+    compute_template.has_resource_properties(
+        "AWS::IAM::Policy",
+        {
+            "PolicyDocument": Match.object_like(
+                {
+                    "Statement": Match.array_with(
+                        [
+                            Match.object_like(
+                                {
+                                    "Sid": "SchedulerAccess",
+                                    "Effect": "Allow",
+                                    "Action": Match.array_with(
+                                        [
+                                            "scheduler:CreateSchedule",
+                                            "scheduler:DeleteSchedule",
+                                            "scheduler:GetSchedule",
+                                            "scheduler:UpdateSchedule",
+                                        ]
+                                    ),
+                                }
+                            )
+                        ]
+                    )
+                }
+            )
+        },
+    )
+
+
+def test_exam_api_scheduler_resource_scoped_to_batch_pollers_group(
+    compute_template: Template,
+) -> None:
+    """The resource ARN is a Fn::Join over region/account; verify the static
+    suffix narrows it to the batch-pollers group only."""
+    policies = compute_template.find_resources("AWS::IAM::Policy")
+    matched = False
+    for resource in policies.values():
+        for stmt in resource["Properties"]["PolicyDocument"]["Statement"]:
+            if stmt.get("Sid") != "SchedulerAccess":
+                continue
+            res = stmt["Resource"]
+            assert isinstance(res, dict) and "Fn::Join" in res, (
+                "Expected Fn::Join ARN for scheduler resource"
+            )
+            joined = "".join(p for p in res["Fn::Join"][1] if isinstance(p, str))
+            assert joined.endswith(":schedule/grading-batch-pollers/*"), (
+                f"Resource not scoped to batch-pollers group: {joined}"
+            )
+            matched = True
+    assert matched, "SchedulerAccess statement not found"
+
+
+def test_exam_api_passrole_scoped_to_scheduler_service(
+    compute_template: Template,
+) -> None:
+    compute_template.has_resource_properties(
+        "AWS::IAM::Policy",
+        {
+            "PolicyDocument": Match.object_like(
+                {
+                    "Statement": Match.array_with(
+                        [
+                            Match.object_like(
+                                {
+                                    "Sid": "SchedulerPassRole",
+                                    "Effect": "Allow",
+                                    "Action": "iam:PassRole",
+                                    "Condition": {
+                                        "StringEquals": {
+                                            "iam:PassedToService": (
+                                                "scheduler.amazonaws.com"
+                                            )
+                                        }
+                                    },
+                                }
+                            )
+                        ]
+                    )
+                }
+            )
+        },
+    )
+
+
+# ── SSM parameters for runtime wiring ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "param_name",
+    [
+        "/grading/lambda/batch-poller-arn",
+        "/grading/scheduler/batch-pollers-group-name",
+        "/grading/scheduler/batch-poller-role-arn",
+    ],
+)
+def test_runtime_wiring_published_to_ssm(
+    compute_template: Template, param_name: str
+) -> None:
+    compute_template.has_resource_properties(
+        "AWS::SSM::Parameter",
+        {"Name": param_name, "Type": "String"},
+    )
+
+
+def test_batch_pollers_group_name_param_is_literal(
+    compute_template: Template,
+) -> None:
+    """The group-name SSM parameter holds the plain string, not a CFN ref —
+    exam-api reads it as a literal name."""
+    compute_template.has_resource_properties(
+        "AWS::SSM::Parameter",
+        {
+            "Name": "/grading/scheduler/batch-pollers-group-name",
+            "Value": "grading-batch-pollers",
+        },
+    )

--- a/infra/tests/test_compute_stack.py
+++ b/infra/tests/test_compute_stack.py
@@ -369,6 +369,9 @@ def test_no_individual_schedules_provisioned(compute_template: Template) -> None
 
 
 def test_scheduler_role_trusts_scheduler_service(compute_template: Template) -> None:
+    """Trust policy must scope to scheduler.amazonaws.com AND constrain both
+    aws:SourceAccount and aws:SourceArn (confused-deputy hardening). Without
+    SourceArn, any schedule in any group could assume this role."""
     compute_template.has_resource_properties(
         "AWS::IAM::Role",
         {
@@ -384,11 +387,18 @@ def test_scheduler_role_trusts_scheduler_service(compute_template: Template) -> 
                                     "Principal": {
                                         "Service": "scheduler.amazonaws.com"
                                     },
-                                    "Condition": {
-                                        "StringEquals": Match.object_like(
-                                            {"aws:SourceAccount": Match.any_value()}
-                                        )
-                                    },
+                                    "Condition": Match.object_like(
+                                        {
+                                            "StringEquals": Match.object_like(
+                                                {
+                                                    "aws:SourceAccount": Match.any_value()
+                                                }
+                                            ),
+                                            "ArnLike": Match.object_like(
+                                                {"aws:SourceArn": Match.any_value()}
+                                            ),
+                                        }
+                                    ),
                                 }
                             )
                         ]
@@ -396,6 +406,31 @@ def test_scheduler_role_trusts_scheduler_service(compute_template: Template) -> 
                 }
             ),
         },
+    )
+
+
+def test_scheduler_role_source_arn_scoped_to_batch_pollers_group(
+    compute_template: Template,
+) -> None:
+    """The aws:SourceArn condition must end with the batch-pollers group ARN
+    suffix — nothing wider should be acceptable."""
+    roles = compute_template.find_resources(
+        "AWS::IAM::Role",
+        {
+            "Properties": Match.object_like(
+                {"RoleName": "grading-batch-poller-scheduler-role"}
+            )
+        },
+    )
+    assert len(roles) == 1
+    statements = next(iter(roles.values()))["Properties"][
+        "AssumeRolePolicyDocument"
+    ]["Statement"]
+    arn_like = statements[0]["Condition"]["ArnLike"]["aws:SourceArn"]
+    assert isinstance(arn_like, dict) and "Fn::Join" in arn_like
+    joined = "".join(p for p in arn_like["Fn::Join"][1] if isinstance(p, str))
+    assert joined.endswith(":schedule/grading-batch-pollers/*"), (
+        f"Trust SourceArn not scoped to batch-pollers group: {joined}"
     )
 
 
@@ -500,33 +535,31 @@ def test_exam_api_scheduler_resource_scoped_to_batch_pollers_group(
 def test_exam_api_passrole_scoped_to_scheduler_service(
     compute_template: Template,
 ) -> None:
-    compute_template.has_resource_properties(
-        "AWS::IAM::Policy",
-        {
-            "PolicyDocument": Match.object_like(
-                {
-                    "Statement": Match.array_with(
-                        [
-                            Match.object_like(
-                                {
-                                    "Sid": "SchedulerPassRole",
-                                    "Effect": "Allow",
-                                    "Action": "iam:PassRole",
-                                    "Condition": {
-                                        "StringEquals": {
-                                            "iam:PassedToService": (
-                                                "scheduler.amazonaws.com"
-                                            )
-                                        }
-                                    },
-                                }
-                            )
-                        ]
-                    )
-                }
+    """PassRole must target ONLY the batch-poller scheduler role and be
+    conditioned on the scheduler service. Widening the resource to "*" or
+    naming any other role must fail this test."""
+    policies = compute_template.find_resources("AWS::IAM::Policy")
+    matched = False
+    for resource in policies.values():
+        for stmt in resource["Properties"]["PolicyDocument"]["Statement"]:
+            if stmt.get("Sid") != "SchedulerPassRole":
+                continue
+            assert stmt["Effect"] == "Allow"
+            assert stmt["Action"] == "iam:PassRole"
+            assert stmt["Condition"] == {
+                "StringEquals": {"iam:PassedToService": "scheduler.amazonaws.com"}
+            }
+            res = stmt["Resource"]
+            assert isinstance(res, dict) and "Fn::GetAtt" in res, (
+                f"Resource must be a single GetAtt on the scheduler role, got {res!r}"
             )
-        },
-    )
+            referenced_logical_id, attr = res["Fn::GetAtt"]
+            assert "BatchPollerSchedulerRole" in referenced_logical_id, (
+                f"Expected scheduler role, got {referenced_logical_id}"
+            )
+            assert attr == "Arn"
+            matched = True
+    assert matched, "SchedulerPassRole statement not found"
 
 
 # ── SSM parameters for runtime wiring ───────────────────────────────────────

--- a/services/exam-api/docker/debug/docker-compose.localstack.yml
+++ b/services/exam-api/docker/debug/docker-compose.localstack.yml
@@ -22,7 +22,7 @@ services:
     container_name: exam-api-localstack
     restart: unless-stopped
     environment:
-      SERVICES: s3,ses,secretsmanager,sqs
+      SERVICES: s3,ses,secretsmanager,sqs,ssm,scheduler,iam,lambda
       AWS_DEFAULT_REGION: us-east-1
       DEBUG: "0"
     ports:

--- a/services/exam-api/docker/robot/docker-compose.localstack.yml
+++ b/services/exam-api/docker/robot/docker-compose.localstack.yml
@@ -22,7 +22,7 @@ services:
     container_name: exam-api-localstack
     restart: unless-stopped
     environment:
-      SERVICES: s3,ses,secretsmanager,sqs
+      SERVICES: s3,ses,secretsmanager,sqs,ssm,scheduler,iam,lambda
       AWS_DEFAULT_REGION: eu-west-1
       DEBUG: "0"
     ports:

--- a/services/exam-api/localstack/init/10-bootstrap.sh
+++ b/services/exam-api/localstack/init/10-bootstrap.sh
@@ -8,6 +8,7 @@ FROM_EMAIL="no-reply@local.grading-cloud"
 BATCH_POLLERS_GROUP_NAME="grading-batch-pollers"
 BATCH_POLLER_FUNCTION_NAME="grading-batch-poller"
 SCHEDULER_ROLE_NAME="grading-batch-poller-scheduler-role"
+BATCH_POLLER_EXECUTION_ROLE_NAME="grading-batch-poller-execution-role"
 
 awslocal s3 mb "s3://${BUCKET_NAME}" >/dev/null
 awslocal ses verify-email-identity --email-address "${FROM_EMAIL}" >/dev/null
@@ -87,6 +88,27 @@ SCHEDULER_ROLE_ARN=$(awslocal iam get-role \
   --role-name "${SCHEDULER_ROLE_NAME}" \
   --query 'Role.Arn' --output text)
 
+# Lambda execution role — distinct from the scheduler role above. Trust must
+# allow lambda.amazonaws.com (real AWS rejects mismatched principals; LocalStack
+# is permissive but we keep parity with prod).
+LAMBDA_TRUST_POLICY='{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "lambda.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}'
+
+awslocal iam create-role \
+  --role-name "${BATCH_POLLER_EXECUTION_ROLE_NAME}" \
+  --assume-role-policy-document "${LAMBDA_TRUST_POLICY}" \
+  >/dev/null 2>&1 || true
+
+BATCH_POLLER_EXECUTION_ROLE_ARN=$(awslocal iam get-role \
+  --role-name "${BATCH_POLLER_EXECUTION_ROLE_NAME}" \
+  --query 'Role.Arn' --output text)
+
 # Minimal handler.py packaged into a zip in /tmp.
 mkdir -p /tmp/batch-poller-stub
 cat >/tmp/batch-poller-stub/handler.py <<'PY'
@@ -99,7 +121,7 @@ awslocal lambda create-function \
   --function-name "${BATCH_POLLER_FUNCTION_NAME}" \
   --runtime python3.12 \
   --handler handler.handler \
-  --role "${SCHEDULER_ROLE_ARN}" \
+  --role "${BATCH_POLLER_EXECUTION_ROLE_ARN}" \
   --zip-file fileb:///tmp/batch-poller-stub.zip \
   --memory-size 256 \
   --timeout 60 \

--- a/services/exam-api/localstack/init/10-bootstrap.sh
+++ b/services/exam-api/localstack/init/10-bootstrap.sh
@@ -2,8 +2,12 @@
 set -euo pipefail
 
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-eu-west-1}}"
+ACCOUNT_ID="000000000000"
 BUCKET_NAME="grading-cloud-local-exam-config"
 FROM_EMAIL="no-reply@local.grading-cloud"
+BATCH_POLLERS_GROUP_NAME="grading-batch-pollers"
+BATCH_POLLER_FUNCTION_NAME="grading-batch-poller"
+SCHEDULER_ROLE_NAME="grading-batch-poller-scheduler-role"
 
 awslocal s3 mb "s3://${BUCKET_NAME}" >/dev/null
 awslocal ses verify-email-identity --email-address "${FROM_EMAIL}" >/dev/null
@@ -54,12 +58,82 @@ PIPELINE_EVENTS_QUEUE_URL=$(awslocal sqs get-queue-url --queue-name "grading-pip
 SPREADSHEET_CONVERSION_QUEUE_URL=$(awslocal sqs get-queue-url --queue-name "grading-spreadsheet-conversion" --query 'QueueUrl' --output text)
 PDF_GENERATION_QUEUE_URL=$(awslocal sqs get-queue-url --queue-name "grading-pdf-generation" --query 'QueueUrl' --output text)
 
+# ── EventBridge Scheduler group ─────────────────────────────────────────────
+# CDK provisions this group; mirror it locally so exam-api can create/delete
+# per-batch schedules against the same name in dev.
+awslocal scheduler create-schedule-group \
+  --name "${BATCH_POLLERS_GROUP_NAME}" \
+  >/dev/null 2>&1 || true
+
+# ── IAM role + placeholder batch-poller Lambda ──────────────────────────────
+# Real ARNs (rather than fake strings) so SSM lookups + schedule creation work
+# end-to-end against LocalStack. The handler is a no-op — the production zip is
+# uploaded by CI in real environments.
+SCHEDULER_TRUST_POLICY='{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "scheduler.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}'
+
+awslocal iam create-role \
+  --role-name "${SCHEDULER_ROLE_NAME}" \
+  --assume-role-policy-document "${SCHEDULER_TRUST_POLICY}" \
+  >/dev/null 2>&1 || true
+
+SCHEDULER_ROLE_ARN=$(awslocal iam get-role \
+  --role-name "${SCHEDULER_ROLE_NAME}" \
+  --query 'Role.Arn' --output text)
+
+# Minimal handler.py packaged into a zip in /tmp.
+mkdir -p /tmp/batch-poller-stub
+cat >/tmp/batch-poller-stub/handler.py <<'PY'
+def handler(event, context):
+    return {"status": "noop", "received": event}
+PY
+(cd /tmp/batch-poller-stub && zip -q -r /tmp/batch-poller-stub.zip handler.py)
+
+awslocal lambda create-function \
+  --function-name "${BATCH_POLLER_FUNCTION_NAME}" \
+  --runtime python3.12 \
+  --handler handler.handler \
+  --role "${SCHEDULER_ROLE_ARN}" \
+  --zip-file fileb:///tmp/batch-poller-stub.zip \
+  --memory-size 256 \
+  --timeout 60 \
+  >/dev/null 2>&1 || true
+
+BATCH_POLLER_LAMBDA_ARN=$(awslocal lambda get-function \
+  --function-name "${BATCH_POLLER_FUNCTION_NAME}" \
+  --query 'Configuration.FunctionArn' --output text)
+
+# ── SSM parameters ─────────────────────────────────────────────────────────
+# Mirror the parameters published by the CDK ComputeStack so exam-api can read
+# them in dev exactly like in prod.
+awslocal ssm put-parameter \
+  --name "/grading/lambda/batch-poller-arn" \
+  --value "${BATCH_POLLER_LAMBDA_ARN}" \
+  --type String --overwrite >/dev/null
+awslocal ssm put-parameter \
+  --name "/grading/scheduler/batch-pollers-group-name" \
+  --value "${BATCH_POLLERS_GROUP_NAME}" \
+  --type String --overwrite >/dev/null
+awslocal ssm put-parameter \
+  --name "/grading/scheduler/batch-poller-role-arn" \
+  --value "${SCHEDULER_ROLE_ARN}" \
+  --type String --overwrite >/dev/null
+
 cat >/tmp/localstack-exam-api.env <<EOF
 AWS_REGION=${REGION}
 AWS_S3_ENDPOINT_URL=http://localstack:4566
 AWS_SES_ENDPOINT_URL=http://localstack:4566
 AWS_SECRETSMANAGER_ENDPOINT_URL=http://localstack:4566
 AWS_SQS_ENDPOINT_URL=http://localstack:4566
+AWS_SSM_ENDPOINT_URL=http://localstack:4566
+AWS_SCHEDULER_ENDPOINT_URL=http://localstack:4566
+AWS_LAMBDA_ENDPOINT_URL=http://localstack:4566
 DATABASE_URL=postgresql+asyncpg://grading_app:grading_pass@exam-api-postgres:5432/grading
 COGNITO_USER_POOL_ID=replace-with-real-cognito-user-pool-id
 COGNITO_APP_CLIENT_ID=replace-with-real-cognito-app-client-id
@@ -69,6 +143,9 @@ EXAM_CONFIG_BUCKET=${BUCKET_NAME}
 PIPELINE_EVENTS_QUEUE_URL=${PIPELINE_EVENTS_QUEUE_URL}
 SPREADSHEET_CONVERSION_QUEUE_URL=${SPREADSHEET_CONVERSION_QUEUE_URL}
 PDF_GENERATION_QUEUE_URL=${PDF_GENERATION_QUEUE_URL}
+BATCH_POLLER_LAMBDA_ARN=${BATCH_POLLER_LAMBDA_ARN}
+BATCH_POLLERS_SCHEDULE_GROUP_NAME=${BATCH_POLLERS_GROUP_NAME}
+BATCH_POLLER_SCHEDULER_ROLE_ARN=${SCHEDULER_ROLE_ARN}
 EOF
 
 cp /tmp/localstack-exam-api.env /var/lib/localstack/localstack-exam-api.env

--- a/services/exam-api/localstack/init/10-bootstrap.sh
+++ b/services/exam-api/localstack/init/10-bootstrap.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-eu-west-1}}"
-ACCOUNT_ID="000000000000"
 BUCKET_NAME="grading-cloud-local-exam-config"
 FROM_EMAIL="no-reply@local.grading-cloud"
 BATCH_POLLERS_GROUP_NAME="grading-batch-pollers"


### PR DESCRIPTION
Closes #5.

## Summary
- Three Lambdas in `ComputeStack`: `grading-spreadsheet-converter` (container, 512 MB / 300s, SQS-triggered, batch_size=1), `grading-pdf-generator` (container, 1024 MB / 300s, SQS-triggered, batch_size=1), `grading-batch-poller` (zip, Python 3.12, 256 MB / 60s, **not** queue-triggered — invoked by EventBridge Scheduler).
- EventBridge Scheduler group `grading-batch-pollers` pre-created. Per-batch schedules are created/deleted dynamically by exam-api at runtime, never via CDK.
- Least-privilege roles: scheduler role with `lambda:InvokeFunction` scoped to the batch-poller only; exam-api task role gets `scheduler:Create/Delete/Get/Update` scoped to `schedule/grading-batch-pollers/*` plus `iam:PassRole` conditioned on `iam:PassedToService=scheduler.amazonaws.com`.
- Three SSM parameters published for exam-api wiring: `/grading/lambda/batch-poller-arn`, `/grading/scheduler/batch-pollers-group-name`, `/grading/scheduler/batch-poller-role-arn`.
- LocalStack init creates a placeholder Lambda + IAM role + scheduler group and populates the same SSM parameters so dev mirrors prod.

## Test plan
- [x] `uv run pytest` from `infra/` — 65 tests pass (19 new tests covering Lambda config, SQS event-source mappings, scheduler group, role trust + invoke scope, IAM `PassRole` condition, SSM parameters)
- [x] `uv run python -c "...synth..."` — CDK synth succeeds, no deprecation warnings
- [x] `bash -n services/exam-api/localstack/init/10-bootstrap.sh` — script syntax valid
- [ ] Manual: `cdk diff GradingComputeStack` against deployed stack
- [ ] Manual: spin up `docker compose -f services/exam-api/docker/robot/docker-compose.localstack.yml up` and verify SSM params + scheduler group are present

## Notes
- `batch-poller` Lambda ships with an inline placeholder handler that raises `NotImplementedError`; the production zip is uploaded by CI in a follow-up issue.
- Container images for `spreadsheet-converter` and `pdf-generator` reference the existing ECR repos with the `latest` tag; the Dockerfiles are out of scope for this chore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)