### PR TITLE
infra(#8): release-triggered CD pipeline and CDK diff PR comment

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   AWS_REGION: ${{ vars.AWS_REGION || 'eu-west-1' }}
-  AWS_OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+  CI_AWS_OIDC_ROLE_ARN: ${{ vars.CI_AWS_OIDC_ROLE_ARN }}
   RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag || github.ref_name }}
 
 # Lambda services (spreadsheet-converter, pdf-generator, batch-poller) are not
@@ -31,7 +31,7 @@ jobs:
         run: |
           set -euo pipefail
           missing=()
-          [ -n "${AWS_OIDC_ROLE_ARN}" ] || missing+=("vars.AWS_OIDC_ROLE_ARN")
+          [ -n "${CI_AWS_OIDC_ROLE_ARN}" ] || missing+=("vars.CI_AWS_OIDC_ROLE_ARN")
           [ -n "${{ vars.SES_FROM_ADDRESS }}" ] || missing+=("vars.SES_FROM_ADDRESS")
           if [ "${#missing[@]}" -gt 0 ]; then
             printf '::error::Missing required repository variable(s): %s\n' "${missing[*]}"
@@ -52,7 +52,7 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ env.AWS_OIDC_ROLE_ARN }}
+          role-to-assume: ${{ env.CI_AWS_OIDC_ROLE_ARN }}
           role-session-name: github-actions-cd-build
           aws-region: ${{ env.AWS_REGION }}
 
@@ -102,7 +102,7 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ env.AWS_OIDC_ROLE_ARN }}
+          role-to-assume: ${{ env.CI_AWS_OIDC_ROLE_ARN }}
           role-session-name: github-actions-cd-deploy
           aws-region: ${{ env.AWS_REGION }}
 
@@ -136,7 +136,7 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ env.AWS_OIDC_ROLE_ARN }}
+          role-to-assume: ${{ env.CI_AWS_OIDC_ROLE_ARN }}
           role-session-name: github-actions-cd-fargate
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -112,6 +112,13 @@ jobs:
       - name: Install infra dependencies
         run: uv sync --directory infra
 
+      - name: Resolve CDK environment
+        run: |
+          set -euo pipefail
+          account="$(aws sts get-caller-identity --query Account --output text)"
+          echo "CDK_DEFAULT_ACCOUNT=${account}" >> "$GITHUB_ENV"
+          echo "CDK_DEFAULT_REGION=${AWS_REGION}" >> "$GITHUB_ENV"
+
       - name: CDK deploy
         working-directory: infra
         env:

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -1,0 +1,148 @@
+name: Backend CD
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag to build/push (defaults to ref name)"
+        required: false
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION || 'eu-west-1' }}
+  AWS_OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+  RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag || github.ref_name }}
+
+# Lambda services (spreadsheet-converter, pdf-generator, batch-poller) are not
+# yet implemented — only their stack scaffolding exists. Build/update steps for
+# them will be added once each service ships its source + Dockerfile (or zip).
+jobs:
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate required configuration
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${AWS_OIDC_ROLE_ARN}" ] || missing+=("vars.AWS_OIDC_ROLE_ARN")
+          [ -n "${{ vars.SES_FROM_ADDRESS }}" ] || missing+=("vars.SES_FROM_ADDRESS")
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf '::error::Missing required repository variable(s): %s\n' "${missing[*]}"
+            exit 1
+          fi
+          echo "Deploying release tag: ${RELEASE_TAG}"
+
+  build-exam-api:
+    name: Build & push exam-api image
+    runs-on: ubuntu-latest
+    needs: preflight
+    outputs:
+      image_tag: ${{ steps.push.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_OIDC_ROLE_ARN }}
+          role-session-name: github-actions-cd-build
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & push image
+        id: push
+        env:
+          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+        run: |
+          set -euo pipefail
+          IMAGE="${REGISTRY}/exam-api"
+          docker buildx build \
+            --file services/exam-api/Dockerfile \
+            --tag "${IMAGE}:latest" \
+            --tag "${IMAGE}:${RELEASE_TAG}" \
+            --push \
+            .
+          echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+
+  cdk-deploy:
+    name: CDK deploy
+    runs-on: ubuntu-latest
+    needs: build-exam-api
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_OIDC_ROLE_ARN }}
+          role-session-name: github-actions-cd-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Install AWS CDK CLI
+        run: npm install -g aws-cdk
+
+      - name: Install infra dependencies
+        run: uv sync --directory infra
+
+      - name: CDK deploy
+        working-directory: infra
+        env:
+          SES_FROM_ADDRESS: ${{ vars.SES_FROM_ADDRESS }}
+        run: |
+          uv run cdk deploy --all \
+            --require-approval never \
+            --parameters "GradingComputeStack:SesFromAddress=${SES_FROM_ADDRESS}"
+
+  update-fargate:
+    name: Force Fargate redeploy
+    runs-on: ubuntu-latest
+    needs: cdk-deploy
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_OIDC_ROLE_ARN }}
+          role-session-name: github-actions-cd-fargate
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Force new deployment & wait for stability
+        # CDK deploy creates a new task definition only when the task config
+        # changes. The image tag is "latest" — same string across releases —
+        # so we must force a new deployment to pull the freshly pushed image.
+        run: |
+          set -euo pipefail
+          aws ecs update-service \
+            --cluster grading-cluster \
+            --service exam-api \
+            --force-new-deployment >/dev/null
+          aws ecs wait services-stable \
+            --cluster grading-cluster \
+            --services exam-api

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -119,7 +119,7 @@ jobs:
       pull-requests: write
     env:
       AWS_REGION: ${{ vars.AWS_REGION || 'eu-west-1' }}
-      AWS_OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      CI_AWS_OIDC_ROLE_ARN: ${{ vars.CI_AWS_OIDC_ROLE_ARN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -139,16 +139,16 @@ jobs:
 
       - name: Validate OIDC role configuration
         run: |
-          if [ -z "${AWS_OIDC_ROLE_ARN}" ]; then
-            echo "Repository variable AWS_OIDC_ROLE_ARN is not set."
+          if [ -z "${CI_AWS_OIDC_ROLE_ARN}" ]; then
+            echo "Repository variable CI_AWS_OIDC_ROLE_ARN is not set."
             echo "CDK synth will run without AWS credentials (works when no CDK lookups are required)."
           fi
 
       - name: Configure AWS credentials (OIDC)
-        if: env.AWS_OIDC_ROLE_ARN != ''
+        if: env.CI_AWS_OIDC_ROLE_ARN != ''
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ env.AWS_OIDC_ROLE_ARN }}
+          role-to-assume: ${{ env.CI_AWS_OIDC_ROLE_ARN }}
           role-session-name: github-actions-cdk-synth
           aws-region: ${{ env.AWS_REGION }}
 
@@ -159,7 +159,7 @@ jobs:
         run: uv sync --directory infra
 
       - name: Resolve CDK environment
-        if: env.AWS_OIDC_ROLE_ARN != ''
+        if: env.CI_AWS_OIDC_ROLE_ARN != ''
         run: |
           set -euo pipefail
           account="$(aws sts get-caller-identity --query Account --output text)"

--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Validate OIDC role configuration
         run: |
@@ -160,7 +160,7 @@ jobs:
 
       - name: Run CDK synth
         working-directory: infra
-        run: uv run cdk synth --no-lookups
+        run: uv run cdk synth
 
       - name: Run CDK diff
         if: github.event_name == 'pull_request'
@@ -168,7 +168,7 @@ jobs:
         working-directory: infra
         run: |
           set +e
-          uv run cdk diff --no-lookups --no-color > diff.txt 2>&1
+          uv run cdk diff --no-color > diff.txt 2>&1
           status=$?
           echo "exitcode=${status}" >> "$GITHUB_OUTPUT"
           cat diff.txt

--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -111,11 +111,12 @@ jobs:
           (cd infra && uv sync --all-groups && uv run pytest tests/)
 
   cdk-synth:
-    name: CDK synth
+    name: CDK synth & diff
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
     env:
       AWS_REGION: ${{ vars.AWS_REGION || 'eu-west-1' }}
       AWS_OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
@@ -160,3 +161,48 @@ jobs:
       - name: Run CDK synth
         working-directory: infra
         run: uv run cdk synth --no-lookups
+
+      - name: Run CDK diff
+        if: github.event_name == 'pull_request'
+        id: cdk-diff
+        working-directory: infra
+        run: |
+          set +e
+          uv run cdk diff --no-lookups --no-color > diff.txt 2>&1
+          status=$?
+          echo "exitcode=${status}" >> "$GITHUB_OUTPUT"
+          cat diff.txt
+          # cdk diff exits 1 when differences exist — that's expected on PRs.
+          if [ "${status}" -gt 1 ]; then exit "${status}"; fi
+
+      - name: Post CDK diff as PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          DIFF_EXIT: ${{ steps.cdk-diff.outputs.exitcode }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- cdk-diff -->';
+            const max = 60_000;
+            let raw = fs.readFileSync('infra/diff.txt', 'utf8');
+            if (raw.length > max) {
+              raw = raw.slice(0, max) + '\n... (truncated)';
+            }
+            const exit = process.env.DIFF_EXIT || '?';
+            const header = exit === '0'
+              ? 'No infrastructure changes.'
+              : 'Infrastructure changes detected.';
+            const body = `${marker}\n## CDK diff\n\n${header}\n\n<details><summary>Full output</summary>\n\n\`\`\`\n${raw}\n\`\`\`\n\n</details>`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 },
+            );
+            const previous = existing.find(c => c.body && c.body.startsWith(marker));
+            if (previous) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: previous.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -158,6 +158,14 @@ jobs:
       - name: Install infra dependencies
         run: uv sync --directory infra
 
+      - name: Resolve CDK environment
+        if: env.AWS_OIDC_ROLE_ARN != ''
+        run: |
+          set -euo pipefail
+          account="$(aws sts get-caller-identity --query Account --output text)"
+          echo "CDK_DEFAULT_ACCOUNT=${account}" >> "$GITHUB_ENV"
+          echo "CDK_DEFAULT_REGION=${AWS_REGION}" >> "$GITHUB_ENV"
+
       - name: Run CDK synth
         working-directory: infra
         run: uv run cdk synth

--- a/infra/app.py
+++ b/infra/app.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import os
+
 import aws_cdk as cdk
 
 from stacks.auth_stack import AuthStack
@@ -9,9 +11,14 @@ from stacks.storage_stack import StorageStack
 
 app = cdk.App()
 
-storage_stack = StorageStack(app, "GradingStorageStack")
-auth_stack = AuthStack(app, "GradingAuthStack")
-database_stack = DatabaseStack(app, "GradingDatabaseStack")
+env = cdk.Environment(
+    account=os.environ.get("CDK_DEFAULT_ACCOUNT"),
+    region=os.environ.get("CDK_DEFAULT_REGION"),
+)
+
+storage_stack = StorageStack(app, "GradingStorageStack", env=env)
+auth_stack = AuthStack(app, "GradingAuthStack", env=env)
+database_stack = DatabaseStack(app, "GradingDatabaseStack", env=env)
 ComputeStack(
     app,
     "GradingComputeStack",
@@ -24,6 +31,7 @@ ComputeStack(
     app_client_id=auth_stack.user_pool_client.user_pool_client_id,
     alb_sg=database_stack.alb_sg,
     fargate_sg=database_stack.fargate_sg,
+    env=env,
 )
 
 app.synth()


### PR DESCRIPTION
Closes the remaining acceptance criteria on #8.

## Summary
- **`backend-cd.yml` (new)** — release-only deploy. Trigger: `release: published` (+ manual `workflow_dispatch`). Pipeline: preflight → build & push `exam-api` image to ECR (tags `latest` + release tag) → `cdk deploy --all --require-approval never` (passing `SesFromAddress` as a CFN parameter) → `aws ecs update-service --force-new-deployment` on `grading-cluster/exam-api` and wait for stability. The Fargate forced redeploy is required because the task definition references `:latest` — the image moves underneath, so CDK alone wouldn't roll the service.
- **`backend-ci-cd.yml`** — extended `cdk-synth` job with `cdk diff --no-lookups` on PRs, posted as a single deduplicated PR comment via a `<!-- cdk-diff -->` marker (truncated at 60 KB). Existing `cdk synth` gate is preserved.

## Deliberate omissions
- Lambda services (`spreadsheet-converter`, `pdf-generator`, `batch-poller`) are still pyproject-only stubs with no Dockerfile/handler. Build & update steps for them are not added yet — header comment in `backend-cd.yml` flags this so the CD doesn't grow stale jobs that always fail. Add per service when source ships.
- CDK bootstrap remains a one-shot manual step (per the issue's technical note).

## Required repo configuration
Settings → Variables (not Secrets — these are non-sensitive):
- `AWS_OIDC_ROLE_ARN` *(already used by the synth job)*
- `SES_FROM_ADDRESS` *(new — verified SES sender for student invites)*
- `AWS_REGION` *(optional, defaults to `eu-west-1`)*

## Test plan
- [ ] Open this PR — confirm a `## CDK diff` comment appears (or "No infrastructure changes." since this PR touches no infra files)
- [ ] Push a no-op commit that touches `infra/` — confirm the existing comment is **updated** (not duplicated)
- [ ] Manually trigger `workflow_dispatch` on `Backend CD` with a tag input — confirm preflight passes and image pushes
- [ ] Cut a GitHub release on `main` — confirm full chain runs and the Fargate service stabilizes on the new image
- [ ] Re-run with `SES_FROM_ADDRESS` unset — confirm preflight fails with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)