### PR TITLE
fix: use Cognito access_token as bearer

### DIFF
--- a/services/exam-api/exam_api/api/auth_router.py
+++ b/services/exam-api/exam_api/api/auth_router.py
@@ -73,6 +73,7 @@ class LoginRequest(BaseModel):
 
 class LoginResponse(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
+    access_token: str
     id_token: str
     refresh_token: str
     expires_in: int
@@ -162,6 +163,7 @@ async def login(
         ) from err
 
     return LoginResponse(
+        access_token=result.tokens.access_token,
         id_token=result.tokens.id_token,
         refresh_token=result.tokens.refresh_token,
         expires_in=result.tokens.expires_in,
@@ -177,6 +179,7 @@ class StudentLoginResponse(BaseModel):
     """Response for POST /auth/student-login (tokens or NEW_PASSWORD_REQUIRED challenge)."""
 
     model_config = ConfigDict(extra="forbid", strict=True)
+    access_token: str | None = None
     id_token: str | None = None
     refresh_token: str | None = None
     expires_in: int | None = None
@@ -207,6 +210,7 @@ class ChangePasswordRequest(BaseModel):
 
 class ChangePasswordResponse(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
+    access_token: str
     id_token: str
     refresh_token: str
     expires_in: int
@@ -252,6 +256,7 @@ async def student_login(
     if tokens is None:
         raise RuntimeError("Login outcome missing tokens despite absent challenge.")
     return StudentLoginResponse(
+        access_token=tokens.access_token,
         id_token=tokens.id_token,
         refresh_token=tokens.refresh_token,
         expires_in=tokens.expires_in,
@@ -292,6 +297,7 @@ async def change_password(
         ) from err
 
     return ChangePasswordResponse(
+        access_token=result.tokens.access_token,
         id_token=result.tokens.id_token,
         refresh_token=result.tokens.refresh_token,
         expires_in=result.tokens.expires_in,

--- a/services/exam-api/exam_api/api/dependencies.py
+++ b/services/exam-api/exam_api/api/dependencies.py
@@ -110,7 +110,7 @@ async def require_teacher(
     request: Request,
     authorization: Annotated[str | None, Header()] = None,
 ) -> CurrentTeacher:
-    """Dependency: ID token must include cognito:groups containing the teachers pool group."""
+    """Dependency: access token must include cognito:groups containing teachers group."""
 
     token = _bearer_token(authorization)
     jwt_verifier = _get_jwt_verifier(request)
@@ -140,7 +140,7 @@ async def require_student(
     request: Request,
     authorization: Annotated[str | None, Header()] = None,
 ) -> CurrentStudent:
-    """Dependency: ID token must include cognito:groups containing the students pool group."""
+    """Dependency: access token must include cognito:groups containing students group."""
 
     token = _bearer_token(authorization)
     jwt_verifier = _get_jwt_verifier(request)
@@ -170,7 +170,7 @@ async def require_admin(
     request: Request,
     authorization: Annotated[str | None, Header()] = None,
 ) -> CurrentAdmin:
-    """Dependency: ID token must include cognito:groups containing the `admin` pool group."""
+    """Dependency: access token must include cognito:groups containing `admin` group."""
     token = _bearer_token(authorization)
     jwt_verifier = _get_jwt_verifier(request)
     claims = await _decode_token(token, jwt_verifier)

--- a/services/exam-api/exam_api/infrastructure/cognito_auth_adapter.py
+++ b/services/exam-api/exam_api/infrastructure/cognito_auth_adapter.py
@@ -318,12 +318,14 @@ class CognitoAuthAdapter(AuthServicePort):
         return self._auth_tokens_from_result(auth_result)
 
     def _auth_tokens_from_result(self, auth_result: dict[str, Any]) -> AuthTokens:
+        access_token = auth_result.get("AccessToken")
         id_token = auth_result.get("IdToken")
         refresh_token = auth_result.get("RefreshToken")
         expires_in = auth_result.get("ExpiresIn")
 
         if (
-            not isinstance(id_token, str)
+            not isinstance(access_token, str)
+            or not isinstance(id_token, str)
             or not isinstance(refresh_token, str)
             or not isinstance(expires_in, int)
         ):
@@ -332,6 +334,7 @@ class CognitoAuthAdapter(AuthServicePort):
             )
 
         return AuthTokens(
+            access_token=access_token,
             id_token=id_token,
             refresh_token=refresh_token,
             expires_in=expires_in,

--- a/services/exam-api/exam_api/infrastructure/cognito_jwt_verifier.py
+++ b/services/exam-api/exam_api/infrastructure/cognito_jwt_verifier.py
@@ -1,4 +1,4 @@
-"""JWT signature verifier for Cognito ID and access tokens."""
+"""JWT signature verifier for Cognito access tokens used as Bearer."""
 
 from __future__ import annotations
 
@@ -56,19 +56,12 @@ class CognitoJwtVerifier:
             options={"verify_aud": False},
         )
         token_use = claims.get("token_use")
-        if token_use == "id":
-            audience = claims.get("aud")
-            if audience != self._audience:
-                raise JWTError("Cognito ID token audience does not match app client id.")
-            return claims
-        if token_use == "access":
-            client_id = claims.get("client_id")
-            if client_id != self._audience:
-                raise JWTError(
-                    "Cognito access token client_id does not match app client id."
-                )
-            return claims
-        raise JWTError("Expected Cognito ID or access token.")
+        if token_use != "access":
+            raise JWTError("Expected Cognito access token.")
+        client_id = claims.get("client_id")
+        if client_id != self._audience:
+            raise JWTError("Cognito access token client_id does not match app client id.")
+        return claims
 
     async def _refresh_jwks(self) -> None:
         if self._http_client is not None:

--- a/services/exam-api/exam_api/infrastructure/cognito_jwt_verifier.py
+++ b/services/exam-api/exam_api/infrastructure/cognito_jwt_verifier.py
@@ -1,4 +1,4 @@
-"""JWT signature verifier for Cognito ID tokens."""
+"""JWT signature verifier for Cognito ID and access tokens."""
 
 from __future__ import annotations
 
@@ -52,13 +52,23 @@ class CognitoJwtVerifier:
             token,
             key,
             algorithms=["RS256"],
-            audience=self._audience,
             issuer=self._issuer,
+            options={"verify_aud": False},
         )
         token_use = claims.get("token_use")
-        if token_use != "id":
-            raise JWTError("Expected Cognito ID token.")
-        return claims
+        if token_use == "id":
+            audience = claims.get("aud")
+            if audience != self._audience:
+                raise JWTError("Cognito ID token audience does not match app client id.")
+            return claims
+        if token_use == "access":
+            client_id = claims.get("client_id")
+            if client_id != self._audience:
+                raise JWTError(
+                    "Cognito access token client_id does not match app client id."
+                )
+            return claims
+        raise JWTError("Expected Cognito ID or access token.")
 
     async def _refresh_jwks(self) -> None:
         if self._http_client is not None:

--- a/services/exam-api/exam_api/ports/auth_service_port.py
+++ b/services/exam-api/exam_api/ports/auth_service_port.py
@@ -10,6 +10,7 @@ from grading_shared.domain.models import StrictModel
 class AuthTokens(StrictModel):
     """Authentication token bundle returned by Cognito login."""
 
+    access_token: str
     id_token: str
     refresh_token: str
     expires_in: int

--- a/services/exam-api/tests/robot/exam_api_ci.robot
+++ b/services/exam-api/tests/robot/exam_api_ci.robot
@@ -120,9 +120,9 @@ Teacher Can Invite Student And Student Scope Is Accessible
     ${student_login_response}=    POST On Session    exam_api    /auth/student-login    json=${student_login_payload}    expected_status=any
     Should Be Equal As Integers    ${student_login_response.status_code}    200
     ${student_login_body}=    Evaluate    $student_login_response.json()
-    Should Not Be Empty    ${student_login_body["id_token"]}
+    Should Not Be Empty    ${student_login_body["access_token"]}
 
-    ${student_headers}=    Create Dictionary    Authorization=Bearer ${student_login_body["id_token"]}
+    ${student_headers}=    Create Dictionary    Authorization=Bearer ${student_login_body["access_token"]}
     ${scope_response}=    GET On Session    exam_api    /exams/${EXAM_ID}/students/${student_id}/scope    headers=${student_headers}    expected_status=any
     Should Be Equal As Integers    ${scope_response.status_code}    200
     ${scope_body}=    Evaluate    $scope_response.json()
@@ -139,7 +139,7 @@ Prepare Authenticated Context
     ${admin_login_response}=    POST On Session    exam_api    /auth/login    json=${admin_payload}    expected_status=any
     Should Be Equal As Integers    ${admin_login_response.status_code}    200
     ${admin_login_body}=    Evaluate    $admin_login_response.json()
-    ${admin_token}=    Set Variable    ${admin_login_body["id_token"]}
+    ${admin_token}=    Set Variable    ${admin_login_body["access_token"]}
     ${admin_headers}=    Create Dictionary    Authorization=Bearer ${admin_token}
     Set Suite Variable    ${ADMIN_HEADERS}    ${admin_headers}
 
@@ -157,7 +157,7 @@ Prepare Authenticated Context
     ${teacher_login_response}=    POST On Session    exam_api    /auth/login    json=${teacher_login_payload}    expected_status=any
     Should Be Equal As Integers    ${teacher_login_response.status_code}    200
     ${teacher_login_body}=    Evaluate    $teacher_login_response.json()
-    ${teacher_token}=    Set Variable    ${teacher_login_body["id_token"]}
+    ${teacher_token}=    Set Variable    ${teacher_login_body["access_token"]}
     ${teacher_headers}=    Create Dictionary    Authorization=Bearer ${teacher_token}
     Set Suite Variable    ${TEACHER_HEADERS}    ${teacher_headers}
 

--- a/services/exam-api/tests/test_async_migration.py
+++ b/services/exam-api/tests/test_async_migration.py
@@ -68,6 +68,7 @@ def test_login_endpoint_uses_async_execute(auth_client: TestClient) -> None:
     mock_use_case.execute = AsyncMock(
         return_value=LoginTeacherResult(
             tokens=AuthTokens(
+                access_token="access",
                 id_token="id",
                 refresh_token="ref",
                 expires_in=3600,

--- a/services/exam-api/tests/test_auth.py
+++ b/services/exam-api/tests/test_auth.py
@@ -171,6 +171,7 @@ async def test_login_returns_auth_tokens() -> None:
     auth = Mock()
     auth.login_teacher = AsyncMock(
         return_value=AuthTokens(
+            access_token="access.jwt.token",
             id_token="id.jwt.token",
             refresh_token="refresh.token",
             expires_in=3600,
@@ -183,6 +184,7 @@ async def test_login_returns_auth_tokens() -> None:
     )
 
     assert result.tokens.id_token == "id.jwt.token"
+    assert result.tokens.access_token == "access.jwt.token"
     assert result.tokens.refresh_token == "refresh.token"
     assert result.tokens.expires_in == 3600
 
@@ -405,6 +407,7 @@ async def test_cognito_login_calls_initiate_auth_and_returns_tokens() -> None:
     cognito.initiate_auth = AsyncMock(
         return_value={
             "AuthenticationResult": {
+                "AccessToken": "access.jwt.token",
                 "IdToken": "id.jwt.token",
                 "RefreshToken": "refresh.token",
                 "ExpiresIn": 3600,
@@ -422,6 +425,7 @@ async def test_cognito_login_calls_initiate_auth_and_returns_tokens() -> None:
     )
 
     assert tokens == AuthTokens(
+        access_token="access.jwt.token",
         id_token="id.jwt.token",
         refresh_token="refresh.token",
         expires_in=3600,
@@ -601,6 +605,7 @@ def test_post_login_200_returns_tokens(client: TestClient) -> None:
     mock_use_case.execute = AsyncMock(
         return_value=LoginTeacherResult(
             tokens=AuthTokens(
+                access_token="access.jwt.token",
                 id_token="id.jwt.token",
                 refresh_token="refresh.token",
                 expires_in=3600,
@@ -616,6 +621,7 @@ def test_post_login_200_returns_tokens(client: TestClient) -> None:
 
     assert response.status_code == 200
     assert response.json() == {
+        "access_token": "access.jwt.token",
         "id_token": "id.jwt.token",
         "refresh_token": "refresh.token",
         "expires_in": 3600,

--- a/services/exam-api/tests/test_cognito_jwt_verifier.py
+++ b/services/exam-api/tests/test_cognito_jwt_verifier.py
@@ -40,8 +40,8 @@ async def test_decode_and_verify_token_refreshes_jwks_for_unknown_kid(
         return_value={
             "sub": "teacher-1",
             "cognito:groups": ["teachers"],
-            "token_use": "id",
-            "aud": "app-client-id",
+            "token_use": "access",
+            "client_id": "app-client-id",
         }
     )
     monkeypatch.setattr(
@@ -137,6 +137,59 @@ async def test_decode_and_verify_token_accepts_access_token(
 
 
 @pytest.mark.asyncio
+async def test_decode_and_verify_token_rejects_id_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verifier = CognitoJwtVerifier(
+        issuer="https://issuer.example.com/pool",
+        audience="app-client-id",
+    )
+    monkeypatch.setattr(
+        "exam_api.infrastructure.cognito_jwt_verifier.jwt.get_unverified_header",
+        lambda token: {"kid": "kid-1"},
+    )
+    mock_response = _FakeResponse(
+        {
+            "keys": [
+                {
+                    "kid": "kid-1",
+                    "kty": "RSA",
+                    "alg": "RS256",
+                    "use": "sig",
+                    "n": "abc",
+                    "e": "AQAB",
+                }
+            ]
+        }
+    )
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    class _CM:
+        async def __aenter__(self) -> AsyncMock:
+            return mock_client
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "exam_api.infrastructure.cognito_jwt_verifier.httpx.AsyncClient",
+        lambda **kwargs: _CM(),
+    )
+    monkeypatch.setattr(
+        "exam_api.infrastructure.cognito_jwt_verifier.jwt.decode",
+        lambda *args, **kwargs: {
+            "token_use": "id",
+            "aud": "app-client-id",
+            "sub": "teacher-1",
+        },
+    )
+
+    with pytest.raises(JWTError, match="Expected Cognito access token"):
+        await verifier.decode_and_verify_token("header.payload.signature")
+
+
+@pytest.mark.asyncio
 async def test_decode_and_verify_token_fails_when_kid_not_found(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -183,8 +236,8 @@ async def test_jwks_refresh_called_once_for_concurrent_unknown_kid(
     decode_mock = Mock(
         return_value={
             "sub": "u",
-            "token_use": "id",
-            "aud": "app-client-id",
+            "token_use": "access",
+            "client_id": "app-client-id",
         }
     )
     monkeypatch.setattr(

--- a/services/exam-api/tests/test_cognito_jwt_verifier.py
+++ b/services/exam-api/tests/test_cognito_jwt_verifier.py
@@ -190,6 +190,61 @@ async def test_decode_and_verify_token_rejects_id_token(
 
 
 @pytest.mark.asyncio
+async def test_decode_and_verify_token_rejects_mismatched_client_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verifier = CognitoJwtVerifier(
+        issuer="https://issuer.example.com/pool",
+        audience="app-client-id",
+    )
+    monkeypatch.setattr(
+        "exam_api.infrastructure.cognito_jwt_verifier.jwt.get_unverified_header",
+        lambda token: {"kid": "kid-1"},
+    )
+    mock_response = _FakeResponse(
+        {
+            "keys": [
+                {
+                    "kid": "kid-1",
+                    "kty": "RSA",
+                    "alg": "RS256",
+                    "use": "sig",
+                    "n": "abc",
+                    "e": "AQAB",
+                }
+            ]
+        }
+    )
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    class _CM:
+        async def __aenter__(self) -> AsyncMock:
+            return mock_client
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "exam_api.infrastructure.cognito_jwt_verifier.httpx.AsyncClient",
+        lambda **kwargs: _CM(),
+    )
+    monkeypatch.setattr(
+        "exam_api.infrastructure.cognito_jwt_verifier.jwt.decode",
+        lambda *args, **kwargs: {
+            "token_use": "access",
+            "client_id": "wrong-id",
+            "sub": "teacher-1",
+        },
+    )
+
+    with pytest.raises(
+        JWTError, match="Cognito access token client_id does not match app client id"
+    ):
+        await verifier.decode_and_verify_token("header.payload.signature")
+
+
+@pytest.mark.asyncio
 async def test_decode_and_verify_token_fails_when_kid_not_found(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/exam-api/tests/test_cognito_jwt_verifier.py
+++ b/services/exam-api/tests/test_cognito_jwt_verifier.py
@@ -41,6 +41,7 @@ async def test_decode_and_verify_token_refreshes_jwks_for_unknown_kid(
             "sub": "teacher-1",
             "cognito:groups": ["teachers"],
             "token_use": "id",
+            "aud": "app-client-id",
         }
     )
     monkeypatch.setattr(
@@ -83,7 +84,7 @@ async def test_decode_and_verify_token_refreshes_jwks_for_unknown_kid(
 
 
 @pytest.mark.asyncio
-async def test_decode_and_verify_token_rejects_non_id_token(
+async def test_decode_and_verify_token_accepts_access_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     verifier = CognitoJwtVerifier(
@@ -124,11 +125,15 @@ async def test_decode_and_verify_token_rejects_non_id_token(
     )
     monkeypatch.setattr(
         "exam_api.infrastructure.cognito_jwt_verifier.jwt.decode",
-        lambda *args, **kwargs: {"token_use": "access"},
+        lambda *args, **kwargs: {
+            "token_use": "access",
+            "client_id": "app-client-id",
+            "sub": "teacher-1",
+        },
     )
 
-    with pytest.raises(JWTError, match="Expected Cognito ID token"):
-        await verifier.decode_and_verify_token("header.payload.signature")
+    claims = await verifier.decode_and_verify_token("header.payload.signature")
+    assert claims["token_use"] == "access"
 
 
 @pytest.mark.asyncio
@@ -179,6 +184,7 @@ async def test_jwks_refresh_called_once_for_concurrent_unknown_kid(
         return_value={
             "sub": "u",
             "token_use": "id",
+            "aud": "app-client-id",
         }
     )
     monkeypatch.setattr(

--- a/services/exam-api/tests/test_student_auth.py
+++ b/services/exam-api/tests/test_student_auth.py
@@ -91,6 +91,7 @@ async def test_login_student_returns_tokens_on_normal_auth() -> None:
     auth = Mock()
     auth.login_student = AsyncMock(
         return_value=AuthTokens(
+            access_token="access.jwt.token",
             id_token="id.jwt.token",
             refresh_token="refresh.token",
             expires_in=3600,
@@ -105,6 +106,7 @@ async def test_login_student_returns_tokens_on_normal_auth() -> None:
     assert result.challenge is None
     assert result.tokens is not None
     assert result.tokens.id_token == "id.jwt.token"
+    assert result.tokens.access_token == "access.jwt.token"
 
 
 @pytest.mark.asyncio
@@ -124,6 +126,7 @@ async def test_change_student_password_returns_tokens() -> None:
     auth = Mock()
     auth.respond_to_new_password_challenge = AsyncMock(
         return_value=AuthTokens(
+            access_token="access.after.change",
             id_token="id.after.change",
             refresh_token="refresh.after",
             expires_in=3600,
@@ -140,6 +143,7 @@ async def test_change_student_password_returns_tokens() -> None:
     )
 
     assert result.tokens.id_token == "id.after.change"
+    assert result.tokens.access_token == "access.after.change"
     auth.respond_to_new_password_challenge.assert_awaited_once_with(
         email="student@school.edu",
         session="cognito-session-token",
@@ -222,6 +226,7 @@ async def test_cognito_adapter_login_student_returns_tokens() -> None:
     cognito.initiate_auth = AsyncMock(
         return_value={
             "AuthenticationResult": {
+                "AccessToken": "access.jwt.token",
                 "IdToken": "id.jwt.token",
                 "RefreshToken": "refresh.token",
                 "ExpiresIn": 3600,
@@ -239,6 +244,7 @@ async def test_cognito_adapter_login_student_returns_tokens() -> None:
     )
 
     assert tokens == AuthTokens(
+        access_token="access.jwt.token",
         id_token="id.jwt.token",
         refresh_token="refresh.token",
         expires_in=3600,
@@ -304,6 +310,7 @@ async def test_cognito_adapter_respond_to_challenge_returns_tokens() -> None:
     cognito.respond_to_auth_challenge = AsyncMock(
         return_value={
             "AuthenticationResult": {
+                "AccessToken": "access.after",
                 "IdToken": "id.after",
                 "RefreshToken": "refresh.after",
                 "ExpiresIn": 3600,
@@ -323,6 +330,7 @@ async def test_cognito_adapter_respond_to_challenge_returns_tokens() -> None:
     )
 
     assert tokens == AuthTokens(
+        access_token="access.after",
         id_token="id.after",
         refresh_token="refresh.after",
         expires_in=3600,
@@ -404,6 +412,7 @@ def test_api_student_login_returns_challenge(client: TestClient) -> None:
 
     assert response.status_code == 200
     assert response.json() == {
+        "access_token": None,
         "id_token": None,
         "refresh_token": None,
         "expires_in": None,
@@ -417,6 +426,7 @@ def test_api_student_login_returns_tokens(client: TestClient) -> None:
     mock_use_case.execute = AsyncMock(
         return_value=LoginStudentResult(
             tokens=AuthTokens(
+                access_token="access.jwt.token",
                 id_token="id.jwt.token",
                 refresh_token="refresh.token",
                 expires_in=3600,
@@ -433,6 +443,7 @@ def test_api_student_login_returns_tokens(client: TestClient) -> None:
 
     assert response.status_code == 200
     assert response.json() == {
+        "access_token": "access.jwt.token",
         "id_token": "id.jwt.token",
         "refresh_token": "refresh.token",
         "expires_in": 3600,
@@ -465,6 +476,7 @@ def test_api_change_password_returns_tokens(client: TestClient) -> None:
     mock_use_case.execute = AsyncMock(
         return_value=ChangeStudentPasswordResult(
             tokens=AuthTokens(
+                access_token="access.after",
                 id_token="id.after",
                 refresh_token="refresh.after",
                 expires_in=3600,
@@ -486,6 +498,7 @@ def test_api_change_password_returns_tokens(client: TestClient) -> None:
 
     assert response.status_code == 200
     assert response.json() == {
+        "access_token": "access.after",
         "id_token": "id.after",
         "refresh_token": "refresh.after",
         "expires_in": 3600,
@@ -553,6 +566,7 @@ async def test_student_id_token_from_challenge_response_contains_claims() -> Non
     cognito.respond_to_auth_challenge = AsyncMock(
         return_value={
             "AuthenticationResult": {
+                "AccessToken": "access.after",
                 "IdToken": id_token,
                 "RefreshToken": "refresh.after",
                 "ExpiresIn": 3600,
@@ -585,6 +599,7 @@ async def test_after_password_change_student_login_called_with_new_password() ->
     auth = Mock()
     auth.respond_to_new_password_challenge = AsyncMock(
         return_value=AuthTokens(
+            access_token="access.after",
             id_token="id.after",
             refresh_token="refresh.after",
             expires_in=3600,
@@ -592,6 +607,7 @@ async def test_after_password_change_student_login_called_with_new_password() ->
     )
     auth.login_student = AsyncMock(
         return_value=AuthTokens(
+            access_token="access.login",
             id_token="id.login",
             refresh_token="refresh.login",
             expires_in=3600,


### PR DESCRIPTION
## Context
[CRITIQUE] `src/pages/login-page.tsx:81` + `src/lib/api/mutator.ts:25` — `id_token` envoye comme Bearer.
`LoginResponse` n'expose que `id_token` (cf. `schemas/loginResponse.ts`), qui est un token d'identite Cognito, pas un token d'acces. Il est ensuite reinjecte en `Authorization: Bearer` sur toutes les requetes API.

## What changed
- Backend auth responses now expose `access_token` in addition to `id_token` and `refresh_token`.
- Cognito token mapping now requires and returns `AccessToken`.
- JWT verifier now accepts only Cognito access tokens for Bearer auth, with strict check:
  - Access token: `client_id` must match app client id.
- Auth-related tests updated to cover token payload and verification behavior.

## Acceptance Criteria
- [ ] `POST /auth/login` response includes `access_token` in the OpenAPI schema and runtime payload.
- [ ] `POST /auth/student-login` response includes nullable `access_token` for challenge flow and populated `access_token` when tokens are issued.
- [ ] `POST /auth/change-password` response includes `access_token`.
- [ ] API endpoints protected by Bearer auth accept a valid Cognito `access_token`.
- [ ] API endpoints protected by Bearer auth reject Cognito `id_token`.
- [ ] Access tokens are rejected when `client_id` does not match the configured app client id.
- [ ] Frontend can send `access_token` as `Authorization: Bearer` without backend contract mismatch.

## Test Plan
- [x] `uv run pytest services/exam-api/tests/test_auth.py services/exam-api/tests/test_student_auth.py services/exam-api/tests/test_cognito_jwt_verifier.py services/exam-api/tests/test_async_migration.py`
- [x] `uv run pytest services/exam-api/tests/test_cognito_jwt_verifier.py`